### PR TITLE
Bug 28209 - Remove redundant definition of overlapped frame presentation timestamp.

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@ table.simple {
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">Media Source Extensions</h1>
   
-  <h2 id="w3c-editor-s-draft-09-march-2015"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2015-03-09">09 March 2015</time></h2>
+  <h2 id="w3c-editor-s-draft-02-april-2015"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2015-04-02">02 April 2015</time></h2>
   <dl>
     
       <dt>This version:</dt>
@@ -2221,8 +2221,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                         <dt>If <var>track buffer</var> contains video <a href="#coded-frame">coded frames</a>:</dt>
                         <dd>
                           <ol>
-                            <li>Let <var>overlapped frame presentation timestamp</var> equal the <a href="#presentation-timestamp">presentation timestamp</a> of <var>overlapped frame</var>.</li>
-                            <li>Let <var>remove window timestamp</var> equal <var>overlapped frame presentation timestamp</var> plus 1 microsecond.</li>
+                            <li>Let <var>remove window timestamp</var> equal the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a> plus 1 microsecond.</li>
                             <li>If the <var>presentation timestamp</var> is less than the <var>remove window timestamp</var>, then remove <var>overlapped frame</var> and any
                               <a href="#coded-frame">coded frames</a> that depend on it from <var>track buffer</var>.
                               <div class="note"><div class="note-title" aria-level="5" role="heading" id="h-note27"><span>Note</span></div><p class="">
@@ -3029,7 +3028,14 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
         </thead>
         <tbody>
         </tbody><tbody>
-          <tr><td>03 February 2015</td>
+          <tr><td>02 April 2015</td>
+            <td>
+              <ul>
+                <li>Bug 28209 - Remove redundant definition of overlapped frame presentation timestamp.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr><td><a href="https://rawgit.com/w3c/media-source/ee9ae4ba1681e34b6e90d172759f984ee64ab4c1/index.html">03 February 2015</a></td>
             <td>
               <ul>
                 <li>Bug 27790 - Make .buffered attributes return the same object if nothing has changed.</li>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -1846,8 +1846,7 @@
                         <dt>If <var>track buffer</var> contains video <a def-id="coded-frames"></a>:</dt>
                         <dd>
                           <ol>
-                            <li>Let <var>overlapped frame presentation timestamp</var> equal the <a def-id="presentation-timestamp"></a> of <var>overlapped frame</var>.</li>
-                            <li>Let <var>remove window timestamp</var> equal <var>overlapped frame presentation timestamp</var> plus 1 microsecond.</li>
+                            <li>Let <var>remove window timestamp</var> equal the <var>overlapped frame</var> <a def-id="presentation-timestamp"></a> plus 1 microsecond.</li>
                             <li>If the <var>presentation timestamp</var> is less than the <var>remove window timestamp</var>, then remove <var>overlapped frame</var> and any
                               <a def-id="coded-frames"></a> that depend on it from <var>track buffer</var>.
                               <p class="note">
@@ -2687,7 +2686,14 @@
         </thead>
         <tbody>
         <tbody>
-          <td>03 February 2015</td>
+          <td>02 April 2015</td>
+            <td>
+              <ul>
+                <li>Bug 28209 - Remove redundant definition of overlapped frame presentation timestamp.</li>
+              </ul>
+            </td>
+          </tr>
+          <td><a href="https://rawgit.com/w3c/media-source/ee9ae4ba1681e34b6e90d172759f984ee64ab4c1/index.html">03 February 2015</td>
             <td>
               <ul>
                 <li>Bug 27790 - Make .buffered attributes return the same object if nothing has changed.</li>


### PR DESCRIPTION
Aaron, please take a look at this first ever MSE spec edit of mine.