### PR TITLE
Fixed #17 & #18: Convert "Detach from Media Element" into an externally referenced algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -1126,8 +1126,9 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
 
         <section id="mediasource-detach" typeof="bibo:Chapter" resource="#mediasource-detach" property="bibo:hasPart">
           <h4 id="h-mediasource-detach" resource="#h-mediasource-detach"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.2 </span>Detaching from a media element</span></h4>
-          <p>The following steps are run in any case where the attached <a href="#idl-def-MediaSource" class="idlType"><code>MediaSource</code></a>, if any, must be detached from the media element.
-          </p><ol>
+          <p>The following steps are run in any case where the media element is going to transition to <a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-network_empty">NETWORK_EMPTY</a> and <a href="https://www.w3.org/TR/html5/webappapis.html#queue-a-task">queue a task</a> to <a href="https://www.w3.org/TR/html5/webappapis.html#fire-a-simple-event">fire a simple event</a> named <a href="https://www.w3.org/TR/html5/embedded-content-0.html#event-mediacontroller-emptied">emptied</a> at the media element. These steps must be run right before the transition.</p>
+
+          <ol>
             <li>Set the <code><a href="#widl-MediaSource-readyState">readyState</a></code> attribute to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code>.</li>
             <li>Update <code><a href="#widl-MediaSource-duration">duration</a></code> to NaN.</li>
             <li>Remove all the <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a> objects from <code><a href="#widl-MediaSource-activeSourceBuffers">activeSourceBuffers</a></code>.</li>
@@ -1139,7 +1140,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>
               <a href="https://www.w3.org/TR/html5/webappapis.html#queue-a-task">Queue a task</a> to <a href="https://www.w3.org/TR/html5/webappapis.html#fire-a-simple-event">fire a simple event</a> named <code><a href="#dom-evt-sourceclose">sourceclose</a></code> at the <a href="#idl-def-MediaSource" class="idlType"><code>MediaSource</code></a>.</li>
           </ol>
-		  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note11"><span>Note</span></div><p class="">This algorithm has been generalized so that it may be called on HTMLMediaElement operations like load and fetch, in addition to when the media element transitions to <a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-network_empty">NETWORK_EMPTY</a>.  [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>]</p></div>
+		  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note11"><span>Note</span></div><p class="">Going forward, this algorithm is intended to be externally called and run in any case where the attached <a href="#idl-def-MediaSource" class="idlType"><code>MediaSource</code></a>, if any, must be detached from the media element.  It may be called on HTMLMediaElement [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>] operations like load() and fetch() in addition to, or in place of, when the media element transitions to <a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-network_empty">NETWORK_EMPTY</a>.</p></div>
         </section>
 
         <section id="mediasource-seeking" typeof="bibo:Chapter" resource="#mediasource-seeking" property="bibo:hasPart">
@@ -3141,7 +3142,7 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
         </thead>
         <tbody>
           <tr>
-		    <td>April 13 2016</td>
+            <td>April 15 2016</td>
             <td>
               <ul>
                 <li>Issue 17 &amp; 18 - Generalize the detach MediaSource algorithm.</li>
@@ -3152,7 +3153,7 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
             <td>13 April 2016</td>
             <td>
               <ul>
-                <li>Issue 25 - Fixed ambiguous behavior with CFP algorithm.</li>
+                <li><a href="https://rawgit.com/w3c/media-source/81b27bc84bc64419abff2b8235dc66418ba53a5a/index.html">Issue 25 - Fixed ambiguous behavior with CFP algorithm.</a></li>
                 <li><a href="https://rawgit.com/w3c/media-source/8aba06a6a10d8fe0bf26b2e4c11a3e5a209244e0/index.html">Issue 11 - Ignore preload attribute on parent media element.</a></li>
               </ul>
             </td>

--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@ table.simple {
     }
 }
 </style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--></head>
-  <body class="h-entry toc-sidebar" role="document" id="respecDocument"><p id="toc-nav"><a id="toc-jump" href="#toc"><span aria-hidden="true">↑</span> <span>Jump to Table of Contents</span></a><a id="toc-toggle" href="#toc"><span aria-hidden="true">←</span> <span>Collapse Sidebar</span></a></p><div class="head" role="contentinfo" id="respecHeader">
+  <body class="h-entry toc-sidebar" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
   <p>
       
         
@@ -1126,8 +1126,8 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
 
         <section id="mediasource-detach" typeof="bibo:Chapter" resource="#mediasource-detach" property="bibo:hasPart">
           <h4 id="h-mediasource-detach" resource="#h-mediasource-detach"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.2 </span>Detaching from a media element</span></h4>
-          <p>The following steps are run in any case where the media element is going to transition to <a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-network_empty">NETWORK_EMPTY</a> and <a href="https://www.w3.org/TR/html5/webappapis.html#queue-a-task">queue a task</a> to <a href="https://www.w3.org/TR/html5/webappapis.html#fire-a-simple-event">fire a simple event</a> named <a href="https://www.w3.org/TR/html5/embedded-content-0.html#event-mediacontroller-emptied">emptied</a> at the media element. These steps must be run right before the transition.</p>
-          <ol>
+          <p>The following steps are run in any case where the attached <a href="#idl-def-MediaSource" class="idlType"><code>MediaSource</code></a>, if any, must be detached from the media element.
+          </p><ol>
             <li>Set the <code><a href="#widl-MediaSource-readyState">readyState</a></code> attribute to <code><a href="#idl-def-ReadyState.closed">"closed"</a></code>.</li>
             <li>Update <code><a href="#widl-MediaSource-duration">duration</a></code> to NaN.</li>
             <li>Remove all the <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a> objects from <code><a href="#widl-MediaSource-activeSourceBuffers">activeSourceBuffers</a></code>.</li>
@@ -1139,6 +1139,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>
               <a href="https://www.w3.org/TR/html5/webappapis.html#queue-a-task">Queue a task</a> to <a href="https://www.w3.org/TR/html5/webappapis.html#fire-a-simple-event">fire a simple event</a> named <code><a href="#dom-evt-sourceclose">sourceclose</a></code> at the <a href="#idl-def-MediaSource" class="idlType"><code>MediaSource</code></a>.</li>
           </ol>
+		  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note11"><span>Note</span></div><p class="">This algorithm has been generalized so that it may be called on HTMLMediaElement operations like load and fetch, in addition to when the media element transitions to <a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-network_empty">NETWORK_EMPTY</a>.  [<cite><a class="bibref" href="#bib-HTML51">HTML51</a></cite>]</p></div>
         </section>
 
         <section id="mediasource-seeking" typeof="bibo:Chapter" resource="#mediasource-seeking" property="bibo:hasPart">
@@ -1156,7 +1157,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                       to <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_metadata">HAVE_METADATA</a></code>.</li>
                     <li>The media element waits until an <code><a href="#widl-SourceBuffer-appendBuffer-void-ArrayBufferView-data">appendBuffer()</a></code> or an <code><a href="#widl-SourceBuffer-appendStream-void-ReadableStream-stream-unsigned-long-long-maxSize">appendStream()</a></code> call causes the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a> to set
                       the <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">HTMLMediaElement.readyState</a></code> attribute to a value greater than <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_metadata">HAVE_METADATA</a></code>.
-                      <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note11"><span>Note</span></div><p class="">The web application can use <code><a href="#widl-SourceBuffer-buffered">buffered</a></code> to determine what the media element needs to resume playback.</p></div>
+                      <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note12"><span>Note</span></div><p class="">The web application can use <code><a href="#widl-SourceBuffer-buffered">buffered</a></code> to determine what the media element needs to resume playback.</p></div>
                     </li>
                   </ol>
                 </dd>
@@ -1180,11 +1181,11 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
           constantly evaluated to determine when to transition the media element into and out of the <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_enough_data">HAVE_ENOUGH_DATA</a></code> ready state.
           These transitions indicate when the user agent believes it has enough data buffered or it needs more data respectively.</p>
 
-          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note12"><span>Note</span></div><p class="">An implementation may choose to use bytes buffered, time buffered, the append rate, or any other metric it sees fit to
+          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note13"><span>Note</span></div><p class="">An implementation may choose to use bytes buffered, time buffered, the append rate, or any other metric it sees fit to
             determine when it has enough data. The metrics used may change during playback so web applications should only rely on the value of
             <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">HTMLMediaElement.readyState</a></code> to determine whether more data is needed or not.</p></div>
 
-          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note13"><span>Note</span></div><p class="">When the media element needs more data, the user agent should transition it from <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_enough_data">HAVE_ENOUGH_DATA</a></code> to
+          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note14"><span>Note</span></div><p class="">When the media element needs more data, the user agent should transition it from <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_enough_data">HAVE_ENOUGH_DATA</a></code> to
             <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_future_data">HAVE_FUTURE_DATA</a></code> early enough for a web application to be able to respond without causing an interruption in playback.
             For example, transitioning when the current playback position is 500ms before the end of the buffered data gives the application roughly
             500ms to append more data before playback stalls.</p></div>
@@ -1315,7 +1316,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
               <a href="#sourcebuffer-range-removal">range removal</a> algorithm with <var>new duration</var> and
               <var>old duration</var> as the start and end of the removal range.
 
-              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note14"><span>Note</span></div><p class="">This preserves audio frames and text cues that start before and end after the <code><a href="#widl-MediaSource-duration">duration</a></code>.</p></div></li>
+              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note15"><span>Note</span></div><p class="">This preserves audio frames and text cues that start before and end after the <code><a href="#widl-MediaSource-duration">duration</a></code>.</p></div></li>
             <li>If a user agent is unable to partially render audio frames or text cues that start before and end after the <code><a href="#widl-MediaSource-duration">duration</a></code>, then run the following steps:
               <ol>
                 <li>Update <var>new duration</var> to the highest end time reported by the <code><a href="#widl-SourceBuffer-buffered">buffered</a></code> attribute across all <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a> objects in <code><a href="#widl-MediaSource-sourceBuffers">sourceBuffers</a></code>.</li>
@@ -1339,7 +1340,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <dd>
                   <ol>
                     <li>Run the <a href="#duration-change-algorithm">duration change algorithm</a> with <var>new duration</var> set to the highest end time reported by the <code><a href="#widl-SourceBuffer-buffered">buffered</a></code> attribute across all <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a> objects in <code><a href="#widl-MediaSource-sourceBuffers">sourceBuffers</a></code>.<br>
-                      <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note15"><span>Note</span></div><p class="">This allows the duration to properly reflect the end of the appended media segments. For example, if the duration was explicitly set to 10 seconds and only media segments for 0 to 5 seconds were appended before endOfStream() was called, then the duration will get updated to 5 seconds.</p></div>
+                      <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note16"><span>Note</span></div><p class="">This allows the duration to properly reflect the end of the appended media segments. For example, if the duration was explicitly set to 10 seconds and only media segments for 0 to 5 seconds were appended before endOfStream() was called, then the duration will get updated to 5 seconds.</p></div>
                     </li>
                     <li>Notify the media element that it now has all of the media data.</li>
                   </ol>
@@ -1694,7 +1695,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             the current <a href="#coded-frame-group">coded frame group</a>. It is set to 0 when the SourceBuffer object is created and gets updated
             by the <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>.
           </p>
-          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note16"><span>Note</span></div><p class="">The <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> stores the highest <a href="#coded-frame-end-timestamp">coded frame end timestamp</a> across all <a href="#track-buffer">track buffers</a> in a <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a>. Therefore, care should be taken in setting the <code><a href="#widl-SourceBuffer-mode">mode</a></code> attribute when appending multiplexed segments in which the timestamps are not aligned across tracks.
+          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note17"><span>Note</span></div><p class="">The <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var> stores the highest <a href="#coded-frame-end-timestamp">coded frame end timestamp</a> across all <a href="#track-buffer">track buffers</a> in a <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a>. Therefore, care should be taken in setting the <code><a href="#widl-SourceBuffer-mode">mode</a></code> attribute when appending multiplexed segments in which the timestamps are not aligned across tracks.
           </p></div>
 
           <p>The <dfn id="sourcebuffer-generate-timestamps-flag" data-dfn-for="" data-dfn-type="dfn">generate timestamps flag</dfn> is a
@@ -1733,7 +1734,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <li>If the <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> is false, then run the <a href="#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true and abort this algorithm.</li>
                 <li>If the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var> contains one or more complete <a href="#coded-frame">coded frames</a>, then run the
                   <a href="#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>.
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note17"><span>Note</span></div><p class="">
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note18"><span>Note</span></div><p class="">
                     The frequency at which the coded frame processing algorithm is run is implementation-specific. The coded frame processing algorithm may
                     be called when the input buffer contains the complete media segment or it may be called multiple times as complete coded frames are
                     added to the input buffer.
@@ -1801,7 +1802,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>Run the <a href="#sourcebuffer-coded-frame-eviction">coded frame eviction algorithm</a>.</li>
             <li>
               <p>If the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> equals true, then throw a <code><a href="https://www.w3.org/TR/html5/infrastructure.html#quotaexceedederror">QuotaExceededError</a></code> exception and abort these step.</p>
-              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note18"><span>Note</span></div><p class="">This is the signal that the implementation was unable to evict enough data to accomodate the append or the append is too big. The web
+              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note19"><span>Note</span></div><p class="">This is the signal that the implementation was unable to evict enough data to accomodate the append or the append is too big. The web
                 application should use <code><a href="#widl-SourceBuffer-remove-void-double-start-unrestricted-double-end">remove()</a></code> to explicitly free up space and/or reduce the size of the append.</p></div>
             </li>
             </ol>
@@ -1835,13 +1836,13 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <li>Wait for either the <var>stream</var>.<a href="https://streams.spec.whatwg.org/#rs-ready">ready</a> promise or
                   the <var>stream</var>.<a href="https://streams.spec.whatwg.org/#rs-closed">closed</a> promise to be resolved or
                   rejected.
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note19"><span>Note</span></div><p class="">This is intended to be similar to <code>Promise.race([<var>stream.ready</var>, <var>stream.closed</var>], continueAppendLoop, continueAppendLoop)</code>,
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note20"><span>Note</span></div><p class="">This is intended to be similar to <code>Promise.race([<var>stream.ready</var>, <var>stream.closed</var>], continueAppendLoop, continueAppendLoop)</code>,
                     where the <code>continueAppendLoop</code> function returns control to this algorithm and
                     starts executing the step that follows this one. If the
                     <a href="#sourcebuffer-stream-append-loop">stream append loop</a> algorithm is aborted while waiting for the promises,
                     continueAppendLoop must not continue the algorithm when it is eventually called.
                   </p></div>
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note20"><span>Note</span></div><p class="">This step is only represented as a blocking wait to make it easier to
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note21"><span>Note</span></div><p class="">This step is only represented as a blocking wait to make it easier to
                     describe the intended behavior. It should not block other JavaScript from executing.
                   </p></div></li>
                 <li>Continue onto the next step.</li>
@@ -1861,7 +1862,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                   following steps:
                   <ol>
                     <li>Let <var>new data</var> equal the value returned by calling <var>data</var>.slice(0, <var>bytesLeft</var>).
-                    <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note21"><span>Note</span></div><p class="">This step and the next one are assuming <var>data</var> is an
+                    <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note22"><span>Note</span></div><p class="">This step and the next one are assuming <var>data</var> is an
                       <code><a href="http://www.khronos.org/registry/typedarray/specs/latest/#ArrayBuffer" class="idlType">ArrayBuffer</a></code>. If <var>data</var> is an
                       <code><a href="http://www.khronos.org/registry/typedarray/specs/latest/#ArrayBufferView" class="idlType">ArrayBufferView</a></code> subarray() should be called instead.</p></div></li>
                     <li>Let <var>remaining data</var> equal the value returned by calling
@@ -1877,7 +1878,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>Run the <a href="#sourcebuffer-coded-frame-eviction">coded frame eviction algorithm</a>.</li>
             <li>
               <p>If the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> equals true, then run the <a href="#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to false and abort this algorithm.</p>
-              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note22"><span>Note</span></div><p class="">The web application should use <code><a href="#widl-SourceBuffer-remove-void-double-start-unrestricted-double-end">remove()</a></code> to free up space in the <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a>.</p></div>
+              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note23"><span>Note</span></div><p class="">The web application should use <code><a href="#widl-SourceBuffer-remove-void-double-start-unrestricted-double-end">remove()</a></code> to free up space in the <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a>.</p></div>
             </li>
             <li>Add <var>data</var> to the end of the <var><a href="#sourcebuffer-input-buffer">input buffer</a></var>.</li>
             <li>Run the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> algorithm.</li>
@@ -1939,7 +1940,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
               <p>If the <var><a href="#first-init-segment-received-flag">first initialization segment received flag</a></var> is false, then run the following steps:</p>
               <ol>
                 <li>If the <a href="#init-segment">initialization segment</a> contains tracks with codecs the user agent does not support, then run the <a href="#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true and abort these steps.
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note23"><span>Note</span></div><p class="">User agents may consider codecs, that would otherwise be supported, as "not supported" here if the codecs were not
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note24"><span>Note</span></div><p class="">User agents may consider codecs, that would otherwise be supported, as "not supported" here if the codecs were not
                     specified in the <var>type</var> parameter passed to <code><a href="#widl-MediaSource-addSourceBuffer-SourceBuffer-DOMString-type">addSourceBuffer()</a></code>. <br>
                     For example, MediaSource.isTypeSupported('video/webm;codecs="vp8,vorbis"') may return true, but if
                     <code><a href="#widl-MediaSource-addSourceBuffer-SourceBuffer-DOMString-type">addSourceBuffer()</a></code> was called with 'video/webm;codecs="vp8"' and a Vorbis track appears in the
@@ -2249,12 +2250,12 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                     <dd>
                       <ol>
                         <li>Let <var>presentation timestamp</var> be a double precision floating point representation of the coded frame's <a href="#presentation-timestamp">presentation timestamp</a> in seconds.
-                          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note24"><span>Note</span></div><p class="">Special processing may be needed to determine the presentation and decode timestamps for timed text frames since this information may not be explicitly
+                          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note25"><span>Note</span></div><p class="">Special processing may be needed to determine the presentation and decode timestamps for timed text frames since this information may not be explicitly
                             present in the underlying format or may be dependent on the order of the frames. Some metadata text tracks, like MPEG2-TS PSI data, may only have implied timestamps.
                             Format specific rules for these situations should be in the <a href="#byte-stream-format-specs">byte stream format specifications</a> or in separate extension specifications.</p></div>
                         </li>
                         <li>Let <var>decode timestamp</var> be a double precision floating point representation of the coded frame's decode timestamp in seconds.
-                          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note25"><span>Note</span></div><p class="">Implementations don't have to internally store timestamps in a double precision floating point representation. This
+                          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note26"><span>Note</span></div><p class="">Implementations don't have to internally store timestamps in a double precision floating point representation. This
                             representation is used here because it is the represention for timestamps in the HTML spec. The intention here is to make the
                             behavior clear without adding unnecessary complexity to the algorithm to deal with the fact that adding a timestampOffset may
                             cause a timestamp rollover in the underlying timestamp representation used by the byte stream format. Implementations can use any
@@ -2314,7 +2315,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <li>Let <var>frame end timestamp</var> equal the sum of <var>presentation timestamp</var> and <var>frame duration</var>.</li>
                 <li>If <var>presentation timestamp</var> is less than <code><a href="#widl-SourceBuffer-appendWindowStart">appendWindowStart</a></code>, then set the <var><a href="#need-RAP-flag">need random access point flag</a></var> to true, drop the
                   coded frame, and jump to the top of the loop to start processing the next coded frame.
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note26"><span>Note</span></div><p class="">Some implementations may choose to collect some of these coded frames that are outside the <a href="#append-window">append window</a> and use them
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note27"><span>Note</span></div><p class="">Some implementations may choose to collect some of these coded frames that are outside the <a href="#append-window">append window</a> and use them
                     to generate a splice at the first coded frame that has a <a href="#presentation-timestamp">presentation timestamp</a> greater than or equal to <code><a href="#widl-SourceBuffer-appendWindowStart">appendWindowStart</a></code> even if
                     that frame is not a <a href="#random-access-point">random access point</a>. Supporting this requires multiple decoders or faster than real-time decoding so for now
                     this behavior will not be a normative requirement.
@@ -2344,7 +2345,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                             <li>Let <var>remove window timestamp</var> equal the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a> plus 1 microsecond.</li>
                             <li>If the <var>presentation timestamp</var> is less than the <var>remove window timestamp</var>, then remove <var>overlapped frame</var> and any
                               <a href="#coded-frame">coded frames</a> that depend on it from <var>track buffer</var>.
-                              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note27"><span>Note</span></div><p class="">
+                              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note28"><span>Note</span></div><p class="">
                                 This is to compensate for minor errors in frame timestamp computations that can appear when converting back and forth between double precision
                                 floating point numbers and rationals. This tolerance allows a frame to replace an existing one as long as it is within 1 microsecond of the existing
                                 frame's start time. Frames that come slightly before an existing frame are handled by the removal step below.
@@ -2373,14 +2374,14 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                     <dt>If detailed information about decoding dependencies is available:</dt>
                     <dd>Remove all <a href="#coded-frame">coded frames</a> from <var>track buffer</var> that have decoding dependencies on the coded frames removed in
                       the previous step.
-                      <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note28"><span>Note</span></div><p class="">For example if an I-frame is removed in the previous step, then all P-frames &amp; B-frames that depend on that I-frame
+                      <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note29"><span>Note</span></div><p class="">For example if an I-frame is removed in the previous step, then all P-frames &amp; B-frames that depend on that I-frame
                         should be removed from <var>track buffer</var>. This makes sure that decode dependencies are properly maintained during overlaps.
                       </p></div>
                     </dd>
                     <dt>Otherwise:</dt>
                     <dd>Remove all <a href="#coded-frame">coded frames</a> between the coded frames removed in the previous step and the next
                       <a href="#random-access-point">random access point</a> after those removed frames.
-                      <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note29"><span>Note</span></div><p class="">Removing all <a href="#coded-frame">coded frames</a> until the next <a href="#random-access-point">random access point</a> is a conservative
+                      <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note30"><span>Note</span></div><p class="">Removing all <a href="#coded-frame">coded frames</a> until the next <a href="#random-access-point">random access point</a> is a conservative
                         estimate of the decoding dependencies since it assumes all frames between the removed frames and the next random access point
                         depended on the frames that were removed.
                       </p></div>
@@ -2402,7 +2403,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <li>If <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var> is unset or <var>frame end timestamp</var> is greater
                   than <var><a href="#highest-end-timestamp">highest end timestamp</a></var>, then set <var><a href="#highest-end-timestamp">highest end timestamp</a></var> for <var>track buffer</var>
                   to <var>frame end timestamp</var>.
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note30"><span>Note</span></div><p class="">The greater than check is needed because bidirectional prediction between coded frames can cause
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note31"><span>Note</span></div><p class="">The greater than check is needed because bidirectional prediction between coded frames can cause
                     <var>presentation timestamp</var> to not be monotonically increasing eventhough the decode timestamps are monotonically increasing.</p></div>
                 </li>
                 <li>If <var>frame end timestamp</var> is greater than <var><a href="#sourcebuffer-group-end-timestamp">group end timestamp</a></var>,
@@ -2450,7 +2451,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <li>
                   <p>If this <a href="#track-buffer">track buffer</a> has a <a href="#random-access-point">random access point</a> timestamp that is greater than or equal to
                     <var>end</var>, then update <var>remove end timestamp</var> to that random access point timestamp.</p>
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note31"><span>Note</span></div><p class="">Random access point timestamps can be different across tracks because the dependencies between <a href="#coded-frame">coded frames</a> within a
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note32"><span>Note</span></div><p class="">Random access point timestamps can be different across tracks because the dependencies between <a href="#coded-frame">coded frames</a> within a
                     track are usually different than the dependencies in another track.</p></div>
                 </li>
                 <li>Remove all media data, from this <a href="#track-buffer">track buffer</a>, that contain starting timestamps greater than or equal to <var>start</var> and less than the <var>remove end timestamp</var>.</li>
@@ -2473,14 +2474,14 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                   <dt>If detailed information about decoding dependencies is available:</dt>
                   <dd>Remove all <a href="#coded-frame">coded frames</a> from this <a href="#track-buffer">track buffer</a> that have decoding dependencies on the coded frames removed in
                     the previous step.
-                    <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note32"><span>Note</span></div><p class="">For example if an I-frame is removed in the previous step, then all P-frames &amp; B-frames that depend on that I-frame
+                    <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note33"><span>Note</span></div><p class="">For example if an I-frame is removed in the previous step, then all P-frames &amp; B-frames that depend on that I-frame
                       should be removed from this <a href="#track-buffer">track buffer</a>.
                     </p></div>
                   </dd>
                   <dt>Otherwise:</dt>
                   <dd>Remove all <a href="#coded-frame">coded frames</a> between the coded frames removed in the previous step and the next
                     <a href="#random-access-point">random access point</a> after those removed frames.
-                    <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note33"><span>Note</span></div><p class="">Removing all <a href="#coded-frame">coded frames</a> until the next <a href="#random-access-point">random access point</a> is a conservative
+                    <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note34"><span>Note</span></div><p class="">Removing all <a href="#coded-frame">coded frames</a> until the next <a href="#random-access-point">random access point</a> is a conservative
                       estimate of the decoding dependencies since it assumes all frames between the removed frames and the next random access point
                       depended on the frames that were removed.
                     </p></div>
@@ -2490,7 +2491,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                   <p>If this object is in <code><a href="#widl-MediaSource-activeSourceBuffers">activeSourceBuffers</a></code>, the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#current-playback-position">current playback position</a> is greater than or equal to
                     <var>start</var> and less than the <var>remove end timestamp</var>, and <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">HTMLMediaElement.readyState</a></code> is greater than
                     <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_metadata">HAVE_METADATA</a></code>, then set the <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-readystate">HTMLMediaElement.readyState</a></code> attribute to <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#dom-media-have_metadata">HAVE_METADATA</a></code> and stall playback.</p>
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note34"><span>Note</span></div><p class="">This transition occurs because media data for the current position has been removed. Playback cannot progress until media for the
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note35"><span>Note</span></div><p class="">This transition occurs because media data for the current position has been removed. Playback cannot progress until media for the
                     <a href="https://www.w3.org/TR/html5/embedded-content-0.html#current-playback-position">current playback position</a> is appended or the <a href="#active-source-buffer-changes">selected/enabled tracks change</a>.</p></div>
                 </li>
               </ol>
@@ -2508,7 +2509,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>If the <var><a href="#sourcebuffer-buffer-full-flag">buffer full flag</a></var> equals false, then abort these steps.</li>
             <li>Let <var>removal ranges</var> equal a list of presentation time ranges that can be evicted from the presentation to make room for the
               <var>new data</var>.
-              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note35"><span>Note</span></div><p class="">Implementations may use different methods for selecting <var>removal ranges</var> so web applications should not depend on a
+              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note36"><span>Note</span></div><p class="">Implementations may use different methods for selecting <var>removal ranges</var> so web applications should not depend on a
                 specific behavior. The web application can use the <code><a href="#widl-SourceBuffer-buffered">buffered</a></code> attribute to observe whether portions of the buffered data have been evicted.
               </p></div>
             </li>
@@ -2532,7 +2533,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>Update <var>presentation timestamp</var> and <var>decode timestamp</var> to the nearest audio sample timestamp based on sample rate of the
               audio in <var>overlapped frame</var>. If a timestamp is equidistant from both audio sample timestamps, then use the higher timestamp. (eg.
               floor(x * sample_rate + 0.5) / sample_rate).
-              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note36"><span>Note</span></div><div class="">
+              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note37"><span>Note</span></div><div class="">
                 <p>For example, given the following values:</p>
                 <ul>
                   <li>The <a href="#presentation-timestamp">presentation timestamp</a> of <var>overlapped frame</var> equals 10.</li>
@@ -2553,13 +2554,13 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                     <li>The <a href="#decode-timestamp">decode timestamp</a> set to the <var>overlapped frame</var> <a href="#decode-timestamp">decode timestamp</a>.</li>
                     <li>The <a href="#coded-frame-duration">coded frame duration</a> set to difference between <var>presentation timestamp</var> and the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
                   </ul>
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note37"><span>Note</span></div><p class="">
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note38"><span>Note</span></div><p class="">
                     Some implementations may apply fades to/from silence to coded frames on either side of the inserted silence to make the transition less
                     jarring.
                   </p></div>
                 </li>
                 <li>Return to caller without providing a splice frame.
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note38"><span>Note</span></div><p class="">
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note39"><span>Note</span></div><p class="">
                     This is intended to allow <var>new coded frame</var> to be added to the <var>track buffer</var> as if
                     <var>overlapped frame</var> had not been in the <var>track buffer</var> to begin with.
                   </p></div>
@@ -2578,12 +2579,12 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                 <li>The <a href="#coded-frame-duration">coded frame duration</a> set to difference between <var>frame end timestamp</var> and the <var>overlapped frame</var> <a href="#presentation-timestamp">presentation timestamp</a>.</li>
                 <li>The fade out coded frames equals <var>fade-out coded frames</var>.</li>
                 <li>The fade in coded frame equal <var>new coded frame</var>.
-                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note39"><span>Note</span></div><p class="">If the <var>new coded frame</var> is less than 5 milliseconds in duration, then coded frames that are appended after the
+                  <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note40"><span>Note</span></div><p class="">If the <var>new coded frame</var> is less than 5 milliseconds in duration, then coded frames that are appended after the
                     <var>new coded frame</var> will be needed to properly render the splice.</p></div>
                 </li>
                 <li>The splice timestamp equals <var>presentation timestamp</var>.</li>
               </ul>
-              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note40"><span>Note</span></div><p class="">See the <a href="#sourcebuffer-audio-splice-rendering-algorithm">audio splice rendering algorithm</a> for details on how this splice frame is rendered.</p></div>
+              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note41"><span>Note</span></div><p class="">See the <a href="#sourcebuffer-audio-splice-rendering-algorithm">audio splice rendering algorithm</a> for details on how this splice frame is rendered.</p></div>
             </li>
           </ol>
         </section>
@@ -2615,7 +2616,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             <li>Copy samples between <var>splice end timestamp</var> to <var>end timestamp</var> from <var>fade in samples</var> into <var>output samples</var>.</li>
             <li>Render <var>output samples</var>.</li>
           </ol>
-          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note41"><span>Note</span></div><div class="">
+          <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note42"><span>Note</span></div><div class="">
             <p>Here is a graphical representation of this algorithm.</p>
             <img src="audio_splice.png" alt="Audio splice diagram">
           </div></div>
@@ -2640,7 +2641,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
             </li><li>Update the <a href="#coded-frame-duration">coded frame duration</a> of the <var>first overlapped frame</var> to <var>presentation timestamp</var> - <var>overlapped presentation timestamp</var>.</li>
             <li>Add <var>first overlapped frame</var> to the <var>track buffer</var>.
             </li><li>Return to caller without providing a splice frame.
-              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note42"><span>Note</span></div><p class="">This is intended to allow <var>new coded frame</var> to be added to the <var>track buffer</var> as if
+              <div class="note"><div class="note-title marker" aria-level="5" role="heading" id="h-note43"><span>Note</span></div><p class="">This is intended to allow <var>new coded frame</var> to be added to the <var>track buffer</var> as if
                 it hadn't overlapped any frames in <var>track buffer</var> to begin with.</p></div>
             </li>
           </ol>
@@ -2810,7 +2811,7 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
               the same <code><a href="#widl-TrackDefault-type">type</a></code> and the same
               <code><a href="#widl-TrackDefault-byteStreamTrackID">byteStreamTrackID</a></code>, then throw a
               <code>TypeError</code> and abort these steps.
-              <div class="note"><div class="note-title marker" aria-level="4" role="heading" id="h-note43"><span>Note</span></div><p class="">This also applies when <code><a href="#widl-TrackDefault-byteStreamTrackID">byteStreamTrackID</a></code> contains
+              <div class="note"><div class="note-title marker" aria-level="4" role="heading" id="h-note44"><span>Note</span></div><p class="">This also applies when <code><a href="#widl-TrackDefault-byteStreamTrackID">byteStreamTrackID</a></code> contains
                 an empty string and ensures that there is only one "byteStreamTrackID independent" default
                 for each <a href="#idl-def-TrackDefaultType" class="idlType"><code>TrackDefaultType</code></a> value.</p></div></li>
             <li>Store a shallow copy of <var>trackDefaults</var> in this new object so the values can be returned
@@ -2837,7 +2838,7 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
           <p>Creates URLs for <a href="#idl-def-MediaSource" class="idlType"><code>MediaSource</code></a> objects.</p>
 
           
-          <div class="note"><div class="note-title marker" aria-level="4" role="heading" id="h-note44"><span>Note</span></div><p class="">This algorithm is intended to mirror the behavior of the <a href="https://www.w3.org/TR/FileAPI/#dfn-createObjectURL">createObjectURL()</a>[<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] method with autoRevoke set to true.</p></div>
+          <div class="note"><div class="note-title marker" aria-level="4" role="heading" id="h-note45"><span>Note</span></div><p class="">This algorithm is intended to mirror the behavior of the <a href="https://www.w3.org/TR/FileAPI/#dfn-createObjectURL">createObjectURL()</a>[<cite><a class="bibref" href="#bib-FILE-API">FILE-API</a></cite>] method with autoRevoke set to true.</p></div>
         <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><td class="prmName">mediaSource</td><td class="prmType"><code><a href="#idl-def-MediaSource" class="idlType"><code>MediaSource</code></a></code></td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em><code><code><a href="https://www.w3.org/TR/WebIDL-1/#idl-DOMString" class="idlType">DOMString</a></code></code></div><p>When this method is invoked, the user agent must run the following steps:</p><ol class="method-algorithm">
             <li>Return a unique <a href="#mediasource-object-url">MediaSource object URL</a> that can be used to dereference the <var>mediaSource</var> argument, and run the rest of the algorithm asynchronously.</li>
             <li><a href="https://www.w3.org/TR/html5/webappapis.html#provide-a-stable-state">provide a stable state</a></li>
@@ -2976,16 +2977,16 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
         mappings for byte stream formats they support to facilitate interoperability. The byte stream format registry [<cite><a class="bibref" href="#bib-MSE-REGISTRY">MSE-REGISTRY</a></cite>] is the authoritative source for these
         mappings. If an implementation claims to support a MIME type listed in the registry, its <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a> implementation must conform to the
         <a href="#byte-stream-format-specs">byte stream format specification</a> listed in the registry entry.</p>
-      <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note45"><span>Note</span></div><p class="">The byte stream format specifications in the registry are not intended to define new storage formats. They simply outline the subset of
+      <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note46"><span>Note</span></div><p class="">The byte stream format specifications in the registry are not intended to define new storage formats. They simply outline the subset of
         existing storage format structures that implementations of this specification will accept.</p></div>
-      <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note46"><span>Note</span></div><p class="">Byte stream format parsing and validation is implemented in the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> algorithm.</p></div>
+      <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note47"><span>Note</span></div><p class="">Byte stream format parsing and validation is implemented in the <a href="#sourcebuffer-segment-parser-loop">segment parser loop</a> algorithm.</p></div>
 
       <p>This section provides general requirements for all byte stream format specifications:</p>
       <ul>
         <li>A byte stream format specification must define <a href="#init-segment">initialization segments</a> and <a href="#media-segment">media segments</a>.</li>
         <li>A byte stream format should provide references for sourcing <a href="#idl-def-AudioTrack" class="idlType"><code>AudioTrack</code></a>, <a href="#idl-def-VideoTrack" class="idlType"><code>VideoTrack</code></a>, and <a href="#idl-def-TextTrack" class="idlType"><code>TextTrack</code></a> attribute values
           from data in <a href="#init-segment">initialization segments</a>.
-          <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note47"><span>Note</span></div><p class="">If the byte stream format covers a format similar to one covered in the in-band tracks spec [<cite><a class="bibref" href="#bib-INBANDTRACKS">INBANDTRACKS</a></cite>], then
+          <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note48"><span>Note</span></div><p class="">If the byte stream format covers a format similar to one covered in the in-band tracks spec [<cite><a class="bibref" href="#bib-INBANDTRACKS">INBANDTRACKS</a></cite>], then
             it should try to use the same attribute mappings so that Media Source Extensions playback and non-Media Source Extensions playback provide the
             same track information.</p></div>
         </li>
@@ -2994,12 +2995,12 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
           <ol>
             <li>
               <p>The number and type of tracks are not consistent.</p>
-              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note48"><span>Note</span></div><p class="">For example, if the first <a href="#init-segment">initialization segment</a> has 2 audio tracks and 1 video track, then all <a href="#init-segment">initialization segments</a> that follow it in the byte stream must describe 2 audio tracks and 1 video track.</p></div>
+              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note49"><span>Note</span></div><p class="">For example, if the first <a href="#init-segment">initialization segment</a> has 2 audio tracks and 1 video track, then all <a href="#init-segment">initialization segments</a> that follow it in the byte stream must describe 2 audio tracks and 1 video track.</p></div>
             </li>
             <li><a href="#track-id">Track IDs</a> are not the same across <a href="#init-segment">initialization segments</a>, for segments describing multiple tracks of a single type. (e.g. 2 audio tracks).</li>
             <li>
               <p>Codecs changes across <a href="#init-segment">initialization segments</a>.</p>
-              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note49"><span>Note</span></div><p class="">For example, a byte stream that starts with an <a href="#init-segment">initialization segment</a> that specifies a single AAC track and later contains an <a href="#init-segment">initialization segment</a> that specifies a single AMR-WB track is not allowed. Support for multiple codecs is handled with multiple <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a> objects.</p></div>
+              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note50"><span>Note</span></div><p class="">For example, a byte stream that starts with an <a href="#init-segment">initialization segment</a> that specifies a single AAC track and later contains an <a href="#init-segment">initialization segment</a> that specifies a single AMR-WB track is not allowed. Support for multiple codecs is handled with multiple <a href="#idl-def-SourceBuffer" class="idlType"><code>SourceBuffer</code></a> objects.</p></div>
             </li>
           </ol>
         </li>
@@ -3008,11 +3009,11 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
             <li><a href="#track-id">Track IDs</a> changing across <a href="#init-segment">initialization segments</a> if the segments describes only one track of each type.</li>
             <li>
               <p>Video frame size changes. The user agent must support seamless playback.</p>
-              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note50"><span>Note</span></div><p class="">This will cause the &lt;video&gt; display region to change size if the web application does not use CSS or HTML attributes (width/height) to constrain the element size.</p></div>
+              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note51"><span>Note</span></div><p class="">This will cause the &lt;video&gt; display region to change size if the web application does not use CSS or HTML attributes (width/height) to constrain the element size.</p></div>
             </li>
             <li>
               <p>Audio channel count changes. The user agent may support this seamlessly and could trigger downmixing.</p>
-              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note51"><span>Note</span></div><p class="">This is a quality of implementation issue because changing the channel count may require reinitializing the audio device, resamplers, and channel mixers which tends to be audible.</p></div>
+              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note52"><span>Note</span></div><p class="">This is a quality of implementation issue because changing the channel count may require reinitializing the audio device, resamplers, and channel mixers which tends to be audible.</p></div>
             </li>
           </ol>
         </li>
@@ -3020,7 +3021,7 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
           <ol>
             <li>Map all timestamps to the same <a href="https://www.w3.org/TR/html5/embedded-content-0.html#media-timeline">media timeline</a>.</li>
             <li>Support seamless playback of <a href="#media-segment">media segments</a> having a timestamp gap smaller than the audio frame size. User agent must not reflect these gaps in the <code><a href="#widl-SourceBuffer-buffered">buffered</a></code> attribute.
-              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note52"><span>Note</span></div><p class="">This is intended to simplify switching between audio streams where the frame boundaries don't always line up across encodings (e.g. Vorbis).</p></div>
+              <div class="note"><div class="note-title marker" aria-level="3" role="heading" id="h-note53"><span>Note</span></div><p class="">This is intended to simplify switching between audio streams where the frame boundaries don't always line up across encodings (e.g. Vorbis).</p></div>
             </li>
           </ol>
         </li>
@@ -3161,7 +3162,14 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
           </tr>
         </thead>
         <tbody>          <tr>
-		    <td>5 February 2016</td>
+		    <td>April 13 2016</td>
+            <td>
+              <ul>
+                <li>Issue 17 - Generalize the detach MediaSource algorithm.</li>
+              </ul>
+            </td>
+          </tr>
+		  <tr><td><a href="https://rawgit.com/w3c/media-source/1482e906f5adc329212d5c4f0f688177e73b9c8a/index.html">5 February 2016</a></td>
             <td>
               <ul>
                 <li>Issue 34 - Replace InvalidAccessError usage with TypeError.</li>
@@ -3170,7 +3178,7 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
             </td>
           </tr>
           <tr>
-		    <td>29 January 2016</td>
+		    <td><a href="https://rawgit.com/w3c/media-source/de6ea96a49379c33c23d3e0c836fc5417f23be5c/index.html">29 January 2016</a></td>
             <td>
               <ul>
                 <li>Issue 23 - Require setting a random access point to prevent the coded frame removal algorithm from introducing a discontinuity at end of current coded frame group.</li>
@@ -3880,6 +3888,7 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
 </dd><dt id="bib-HTML5">[HTML5]</dt><dd>Ian Hickson; Robin Berjon; Steve Faulkner; Travis Leithead; Erika Doyle Navara; Edward O'Connor; Silvia Pfeiffer. <a href="http://www.w3.org/TR/html5/" property="dc:requires"><cite>HTML5</cite></a>. 28 October 2014. W3C Recommendation. URL: <a href="http://www.w3.org/TR/html5/" property="dc:requires">http://www.w3.org/TR/html5/</a>
 </dd><dt id="bib-TYPED-ARRAYS">[TYPED-ARRAYS]</dt><dd>David Herman; Kenneth Russell. <a href="https://www.khronos.org/registry/typedarray/specs/latest/" property="dc:requires"><cite>Typed Array Specification</cite></a>. 26 June 2013. Khronos Working Draft. URL: <a href="https://www.khronos.org/registry/typedarray/specs/latest/" property="dc:requires">https://www.khronos.org/registry/typedarray/specs/latest/</a>
 </dd><dt id="bib-WHATWG-STREAMS-API">[WHATWG-STREAMS-API]</dt><dd>Domenic Denicola; Takeshi Yoshino. <a href="https://streams.spec.whatwg.org/" property="dc:requires"><cite>WHATWG Streams API</cite></a>. URL: <a href="https://streams.spec.whatwg.org/" property="dc:requires">https://streams.spec.whatwg.org/</a>
-</dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
+</dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-HTML51">[HTML51]</dt><dd>Steve Faulkner; Arron Eicholz; Travis Leithead; Alex Danilo. <a href="http://www.w3.org/TR/html51/" property="dc:references"><cite>HTML 5.1</cite></a>. 12 April 2016. W3C Working Draft. URL: <a href="http://www.w3.org/TR/html51/" property="dc:references">http://www.w3.org/TR/html51/</a>
+</dd><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
 </dd><dt id="bib-MSE-REGISTRY">[MSE-REGISTRY]</dt><dd>Aaron Colwell. <a href="byte-stream-format-registry.html" property="dc:references"><cite>Media Source Extensions Byte Stream Format Registry</cite></a>. URL: <a href="byte-stream-format-registry.html" property="dc:references">byte-stream-format-registry.html</a>
 </dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -644,7 +644,7 @@
 
         <section id="mediasource-detach">
           <h4>Detaching from a media element</h4>
-          <p>The following steps are run in any case where the media element is going to transition to <a def-id="videoref" name="dom-media-network_empty">NETWORK_EMPTY</a> and <a def-id="queue-a-task-to-fire-an-event-named"></a> <a def-id="videoref" name="event-mediacontroller-emptied">emptied</a> at the media element. These steps must be run right before the transition.</p>
+          <p>The following steps are run in any case where the attached <a>MediaSource</a>, if any, must be detached from the media element</a>.
           <ol>
             <li>Set the <a def-id="readyState"></a> attribute to <a def-id="closed"></a>.</li>
             <li>Update <a def-id="duration"></a> to NaN.</li>
@@ -657,6 +657,7 @@
             <li>
               <a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="sourceclose"></a> at the <a>MediaSource</a>.</li>
           </ol>
+		  <p class="note">This algorithm has been generalized so that it may be called on HTMLMediaElement operations like load and fetch, in addition to when the media element transitions to <a def-id="videoref" name="dom-media-network_empty">NETWORK_EMPTY</a>.  [[HTML51]]</p>
         </section>
 
         <section id="mediasource-seeking">
@@ -2742,7 +2743,14 @@
           </tr>
         </thead>
         <tbody>          <tr>
-		    <td>5 February 2016</td>
+		    <td>April 13 2016</td>
+            <td>
+              <ul>
+                <li>Issue 17 - Generalize the detach MediaSource algorithm.</li>
+              </ul>
+            </td>
+          </tr>
+		  <td><a href="https://rawgit.com/w3c/media-source/1482e906f5adc329212d5c4f0f688177e73b9c8a/index.html">5 February 2016</td>
             <td>
               <ul>
                 <li>Issue 34 - Replace InvalidAccessError usage with TypeError.</li>
@@ -2751,7 +2759,7 @@
             </td>
           </tr>
           <tr>
-		    <td>29 January 2016</td>
+		    <td><a href="https://rawgit.com/w3c/media-source/de6ea96a49379c33c23d3e0c836fc5417f23be5c/index.html">29 January 2016</td>
             <td>
               <ul>
                 <li>Issue 23 - Require setting a random access point to prevent the coded frame removal algorithm from introducing a discontinuity at end of current coded frame group.</li>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -644,7 +644,8 @@
 
         <section id="mediasource-detach">
           <h4>Detaching from a media element</h4>
-          <p>The following steps are run in any case where the attached <a>MediaSource</a>, if any, must be detached from the media element</a>.
+          <p>The following steps are run in any case where the media element is going to transition to <a def-id="videoref" name="dom-media-network_empty">NETWORK_EMPTY</a> and <a def-id="queue-a-task-to-fire-an-event-named"></a> <a def-id="videoref" name="event-mediacontroller-emptied">emptied</a> at the media element. These steps must be run right before the transition.</p>
+
           <ol>
             <li>Set the <a def-id="readyState"></a> attribute to <a def-id="closed"></a>.</li>
             <li>Update <a def-id="duration"></a> to NaN.</li>
@@ -657,7 +658,7 @@
             <li>
               <a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="sourceclose"></a> at the <a>MediaSource</a>.</li>
           </ol>
-		  <p class="note">This algorithm has been generalized so that it may be called on HTMLMediaElement operations like load and fetch, in addition to when the media element transitions to <a def-id="videoref" name="dom-media-network_empty">NETWORK_EMPTY</a>.  [[HTML51]]</p>
+		  <p class="note">Going forward, this algorithm is intended to be externally called and run in any case where the attached <a>MediaSource</a>, if any, must be detached from the media element.  It may be called on HTMLMediaElement [[HTML51]] operations like load() and fetch() in addition to, or in place of, when the media element transitions to <a def-id="videoref" name="dom-media-network_empty">NETWORK_EMPTY</a>.</p>
         </section>
 
         <section id="mediasource-seeking">
@@ -2722,7 +2723,7 @@
         </thead>
         <tbody>
           <tr>
-		    <td>April 13 2016</td>
+            <td>April 15 2016</td>
             <td>
               <ul>
                 <li>Issue 17 &amp; 18 - Generalize the detach MediaSource algorithm.</li>
@@ -2733,7 +2734,7 @@
             <td>13 April 2016</td>
             <td>
               <ul>
-                <li>Issue 25 - Fixed ambiguous behavior with CFP algorithm.</li>
+                <li><a href="https://rawgit.com/w3c/media-source/81b27bc84bc64419abff2b8235dc66418ba53a5a/index.html">Issue 25 - Fixed ambiguous behavior with CFP algorithm.</a></li>
                 <li><a href="https://rawgit.com/w3c/media-source/8aba06a6a10d8fe0bf26b2e4c11a3e5a209244e0/index.html">Issue 11 - Ignore preload attribute on parent media element.</a></li>
               </ul>
             </td>


### PR DESCRIPTION
Generalized the MediaSource detach algorithm so that it can be called
for other HTMLMediaElement conditions.

resource=#mediasource-detach