### PR TITLE
Update index.html with the correct date from respec

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,7 +454,7 @@ table.simple {
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">Media Source Extensions</h1>
   
-  <h2 id="w3c-editor-s-draft-11-april-2015"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2015-04-11">11 April 2015</time></h2>
+  <h2 id="w3c-editor-s-draft-11-april-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-04-11">11 April 2016</time></h2>
   <dl>
     
       <dt>This version:</dt>
@@ -580,7 +580,7 @@ table.simple {
     
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2015
+        2016
         
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,


### PR DESCRIPTION
Though the previous commit changed media-source-respec.html to have the correct publishDate, I hadn't re-updated index.html before landing it. This change does precisely that, and I'll merge it soon.