### PR TITLE
Issue #11: Ignore preload attribute on parent media element.

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,7 +454,7 @@ table.simple {
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">Media Source Extensions</h1>
   
-  <h2 id="w3c-editor-s-draft-11-april-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-04-11">11 April 2016</time></h2>
+  <h2 id="w3c-editor-s-draft-13-april-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-04-13">13 April 2016</time></h2>
   <dl>
     
       <dt>This version:</dt>
@@ -1104,7 +1104,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
         <section id="mediasource-attach" typeof="bibo:Chapter" resource="#mediasource-attach" property="bibo:hasPart">
           <h4 id="h-mediasource-attach" resource="#h-mediasource-attach"><span property="xhv:role" resource="xhv:heading"><span class="secno">2.4.1 </span>Attaching to a media element</span></h4>
           <p> A <a href="#idl-def-MediaSource" class="idlType"><code>MediaSource</code></a> object can be attached to a media element by assigning a <a href="#mediasource-object-url">MediaSource object URL</a> to the media element <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#attr-media-src">src</a></code> attribute or the src attribute of a &lt;source&gt; inside a media element. A <a href="#mediasource-object-url">MediaSource object URL</a> is created by passing a MediaSource object to <code><a href="#widl-URL-createObjectURL-DOMString-MediaSource-mediaSource">createObjectURL()</a></code>.</p>
-          <p>If the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a> absolute URL matches the MediaSource object URL, run the following steps right before the <span>"<i>Perform a potentially CORS-enabled fetch</i>"</span>
+          <p>If the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a> absolute URL matches the MediaSource object URL, ignore any <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#attr-media-preload">preload</a></code> attribute of the media element, skip any optional steps for when <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#attr-media-preload">preload</a></code> equals <code><a href="https://www.w3.org/TR/html5/embedded-content-0.html#attr-media-preload-none">none</a></code>, and run the following steps right before the <span>"<i>Perform a potentially CORS-enabled fetch</i>"</span>
             step in the <a href="https://www.w3.org/TR/html5/embedded-content-0.html#concept-media-load-resource">resource fetch algorithm</a>.</p>
 
           <dl class="switch">
@@ -3162,7 +3162,15 @@ interface <span class="idlInterfaceID">TrackDefaultList</span> {
         </thead>
         <tbody>
           <tr>
-            <td>11 April 2016</td>
+            <td>13 April 2016</td>
+            <td>
+              <ul>
+                <li>Issue 11 - Ignore preload attribute on parent media element.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td><a href="https://rawgit.com/w3c/media-source/0c03baa308a5b634860e7536d636f161fe089232/index.html">11 April 2016</a></td>
             <td>
               <ul>
                 <li>Corrected the editor's draft publish date.</li>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -20,7 +20,7 @@
       // if this is a LCWD, uncomment and set the end of its review period
       // lcEnd: "2009-08-05",
 
-      publishDate: "2016-04-11",
+      publishDate: "2016-04-13",
       previousMaturity: "CR",
       previousPublishDate: "2015-11-12",
 
@@ -622,7 +622,7 @@
         <section id="mediasource-attach">
           <h4>Attaching to a media element</h4>
           <p> A <a>MediaSource</a> object can be attached to a media element by assigning a <a def-id="MediaSource-object-URL"></a> to the media element <a def-id="media-src"></a> attribute or the src attribute of a &lt;source&gt; inside a media element. A <a def-id="MediaSource-object-URL"></a> is created by passing a MediaSource object to <a def-id="createObjectURL"></a>.</p>
-          <p>If the <a def-id="resource-fetch-algorithm"></a> absolute URL matches the MediaSource object URL, run the following steps right before the <a def-id="perform-potentially-cors-enabled-fetch"></a>
+          <p>If the <a def-id="resource-fetch-algorithm"></a> absolute URL matches the MediaSource object URL, ignore any <a def-id="preload"></a> attribute of the media element, skip any optional steps for when <a def-id="preload"></a> equals <a def-id="preload-none"></a>, and run the following steps right before the <a def-id="perform-potentially-cors-enabled-fetch"></a>
             step in the <a def-id="resource-fetch-algorithm"></a>.</p>
 
           <dl class="switch">
@@ -2743,7 +2743,15 @@
         </thead>
         <tbody>
           <tr>
-            <td>11 April 2016</td>
+            <td>13 April 2016</td>
+            <td>
+              <ul>
+                <li>Issue 11 - Ignore preload attribute on parent media element.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td><a href="https://rawgit.com/w3c/media-source/0c03baa308a5b634860e7536d636f161fe089232/index.html">11 April 2016</a></td>
             <td>
               <ul>
                 <li>Corrected the editor's draft publish date.</li>

--- a/media-source.js
+++ b/media-source.js
@@ -287,6 +287,8 @@
     'normalized-timeranges-object': { func: videoref_helper, fragment: 'normalized-timeranges-object', link_text: 'normalized TimeRanges object',  },
     'current-playback-position': { func: videoref_helper, fragment: 'current-playback-position', link_text: 'current playback position',  },
     'media-data-is-corrupted': { func: videoref_helper, fragment: 'fatal-decode-error', link_text: 'media data is corrupted',  },
+    'preload': { func: code_videoref_helper, fragment: 'attr-media-preload', link_text: 'preload', },
+    'preload-none': {func: code_videoref_helper, fragment: 'attr-media-preload-none', link_text: 'none', },
     'media-src': { func: code_videoref_helper, fragment: 'attr-media-src', link_text: 'src',  },
     'timerange': { func: code_videoref_helper, fragment: 'timeranges', link_text: 'TimeRange',  },
     'timeranges': { func: code_videoref_helper, fragment: 'timeranges', link_text: 'TimeRanges',  },


### PR DESCRIPTION
@jdsmith3000 please take a look. I believe this fixes issue 11, retaining linkages into the normatively referenced (by MSE spec) W3C HTML5 spec, for example: https://www.w3.org/TR/html5/embedded-content-0.html#attr-media-preload
