### PR TITLE
Fix #115: Add conformance section and use RFC2119 in byte stream formats and registry

### DIFF
--- a/byte-stream-format-registry-respec.html
+++ b/byte-stream-format-registry-respec.html
@@ -25,7 +25,12 @@
       // editors, add as many as you like
       // only "name" is required
       editors:  [
-      { name: "Aaron Colwell",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
+      { name: "Matthew Wolenetz",  url: "",
+      company: "Google Inc.", companyURL: "http://www.google.com/" },
+      { name: "Jerry Smith", url: "",
+      company: "Microsoft Corporation", companyURL: "http://www.microsoft.com/" },
+      { name: "Aaron Colwell (until April 2015)",  url: "",
+      company: "Google Inc.", companyURL: "http://www.google.com/" },
       ],
 
       mseDefGroupName: "byte-stream-format-registry",
@@ -34,7 +39,7 @@
       ],
 
       // name of the WG
-      wg:           "HTML Working Group",
+      wg:           "HTML Media Extensions Working Group",
 
       // URI of the public WG page
       wgURI:        "http://www.w3.org/html/wg/",
@@ -102,19 +107,19 @@
     <section id="entry-requirements">
       <h2>Registration Entry Requirements</h2>
       <ol>
-        <li>Each entry must include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it should use the
+        <li>Each entry MUST include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it SHOULD use the
           MIME-type/subtype pairs typically used for the file format.</li>
-        <li>Each entry must include a <a def-id="generate-timestamps-flag"></a> value that must be used by
+        <li>Each entry MUST include a <a def-id="generate-timestamps-flag"></a> value that MUST be used by
             <a class="externalDFN">SourceBuffer</a> when handling the byte stream format.</li>
-        <li>Each entry must include a link that references a publically available specification. It is recommended that such a specification be made available
+        <li>Each entry MUST include a link that references a publically available specification. It is recommended that such a specification be made available
           without cost (other than reasonable shipping and handling if not available by online means).</li>
-        <li>Each entry must comply with all requirements outlined in the <a def-id="byte-stream-formats-section"></a>
+        <li>Each entry MUST comply with all requirements outlined in the <a def-id="byte-stream-formats-section"></a>
           of the <a def-id="mse-spec"></a> specification.</li>
-        <li>Candidate entries must be announced on <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>(<a href="mailto:public-html-media-request@w3.org">subscribe</a>,
+        <li>Candidate entries MUST be announced on <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>(<a href="mailto:public-html-media-request@w3.org">subscribe</a>,
           <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>) so they can be discussed and evaluated for compliance before being added to the
           registry.</li>
       </ol>
-      <p>If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry (without prejudice).
+      <p>If a registration fails to satisfy a mandatory requirement specified above, then it MAY be removed from the registry (without prejudice).
     </section>
 
     <section id="registry">
@@ -163,5 +168,6 @@
         </tbody>
       </table>
     </section>
+    <section id="conformance"></section>
   </body>
 </html>

--- a/byte-stream-format-registry.html
+++ b/byte-stream-format-registry.html
@@ -136,18 +136,63 @@ table.simple {
         display: none;
     }
 }
-</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--></head>
+</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
+  "specStatus": "ED",
+  "shortName": "",
+  "edDraftURI": "https://w3c.github.io/media-source/byte-stream-format-registry.html",
+  "prevVersion": "http://www.w3.org/2013/12/byte-stream-format-registry/",
+  "editors": [
+    {
+      "name": "Matthew Wolenetz",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    },
+    {
+      "name": "Jerry Smith",
+      "url": "",
+      "company": "Microsoft Corporation",
+      "companyURL": "http://www.microsoft.com/"
+    },
+    {
+      "name": "Aaron Colwell (until April 2015)",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    }
+  ],
+  "mseDefGroupName": "byte-stream-format-registry",
+  "mseUnusedGroupNameExcludeList": [
+    "media-source"
+  ],
+  "mseContributors": [],
+  "wg": "HTML Media Extensions Working Group",
+  "wgURI": "http://www.w3.org/html/wg/",
+  "wgPublicList": "public-html-media",
+  "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/40318/status",
+  "noIDLIn": true,
+  "scheme": "https",
+  "preProcess": [
+    null
+  ],
+  "definitionMap": {},
+  "postProcess": [
+    null
+  ]
+}</script></head>
   <body class="h-entry" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
   <p>
       
         
-            <a href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/Icons/w3c_home" alt="W3C"></a>
+            <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/Icons/w3c_home" alt="W3C"></a>
+            
+            
         
       
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">Media Source Extensions Byte Stream Format Registry</h1>
   
-  <h2 id="w3c-editor-s-draft-09-march-2015"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2015-03-09">09 March 2015</time></h2>
+  <h2 id="w3c-editor-s-draft-20-july-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-07-20">20 July 2016</time></h2>
   <dl>
     
       <dt>This version:</dt>
@@ -167,8 +212,14 @@ table.simple {
     
     
     
-    <dt>Editor:</dt>
-    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+    <dt>Editors:</dt>
+    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Matthew Wolenetz</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+<span property="rdf:rest" resource="_:editor1"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Jerry Smith</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
+<span property="rdf:rest" resource="_:editor2"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
 <span property="rdf:rest" resource="rdf:nil"></span>
 </dd>
 
@@ -182,7 +233,7 @@ table.simple {
     
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2015
+        2016
         
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
@@ -192,13 +243,15 @@ table.simple {
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
         
-          <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+          
+            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+          
         
         rules apply.
       </p>
     
   
-  <hr>
+  <hr title="Separator for header">
 </div>
 
     <section id="purpose" typeof="bibo:Chapter" resource="#purpose" property="bibo:hasPart">
@@ -222,19 +275,19 @@ table.simple {
     <section id="entry-requirements" typeof="bibo:Chapter" resource="#entry-requirements" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-entry-requirements" resource="#h-entry-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Registration Entry Requirements</span></h2>
       <ol>
-        <li>Each entry must include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it should use the
+        <li>Each entry <em class="rfc2119" title="MUST">MUST</em> include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it <em class="rfc2119" title="SHOULD">SHOULD</em> use the
           MIME-type/subtype pairs typically used for the file format.</li>
-        <li>Each entry must include a <var><a href="index.html#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> value that must be used by
+        <li>Each entry <em class="rfc2119" title="MUST">MUST</em> include a <var><a href="index.html#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> value that <em class="rfc2119" title="MUST">MUST</em> be used by
             <code><a href="index.html#idl-def-SourceBuffer" class="idlType">SourceBuffer</a></code> when handling the byte stream format.</li>
-        <li>Each entry must include a link that references a publically available specification. It is recommended that such a specification be made available
+        <li>Each entry <em class="rfc2119" title="MUST">MUST</em> include a link that references a publically available specification. It is recommended that such a specification be made available
           without cost (other than reasonable shipping and handling if not available by online means).</li>
-        <li>Each entry must comply with all requirements outlined in the <a href="index.html#byte-stream-formats">byte stream formats section</a>
+        <li>Each entry <em class="rfc2119" title="MUST">MUST</em> comply with all requirements outlined in the <a href="index.html#byte-stream-formats">byte stream formats section</a>
           of the <a href="index.html#">Media Source Extensions</a> specification.</li>
-        <li>Candidate entries must be announced on <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>(<a href="mailto:public-html-media-request@w3.org">subscribe</a>,
+        <li>Candidate entries <em class="rfc2119" title="MUST">MUST</em> be announced on <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>(<a href="mailto:public-html-media-request@w3.org">subscribe</a>,
           <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>) so they can be discussed and evaluated for compliance before being added to the
           registry.</li>
       </ol>
-      <p>If a registration fails to satisfy a mandatory requirement specified above, then it may be removed from the registry (without prejudice).
+      <p>If a registration fails to satisfy a mandatory requirement specified above, then it <em class="rfc2119" title="MAY">MAY</em> be removed from the registry (without prejudice).
     </p></section>
 
     <section id="registry" typeof="bibo:Chapter" resource="#registry" property="bibo:hasPart">
@@ -283,6 +336,17 @@ table.simple {
         </tbody>
       </table>
     </section>
+    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart"><!--OddPage--><h2 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Conformance</span></h2>
+<p>
+  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
+  and notes in this specification are non-normative. Everything else in this specification is
+  normative.
+</p>
+<p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are 
+  to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+</p>
+</section>
   
 
-<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form></body></html>
+<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+</dd></dl></section></section></body></html>

--- a/index.html
+++ b/index.html
@@ -3234,6 +3234,7 @@ partial interface <span class="idlInterfaceID">URL</span> {
             <td>
               <ul>
                 <li>Issue 59 - Correct i.e. and e.g. style.</li>
+                <li>Issue 115 - Updated byte stream format registry editors in localbiblio.</li>
               </ul>
             </td>
           </tr>
@@ -4077,5 +4078,5 @@ partial interface <span class="idlInterfaceID">URL</span> {
 </dd><dt id="bib-TYPED-ARRAYS">[TYPED-ARRAYS]</dt><dd>David Herman; Kenneth Russell. <a href="https://www.khronos.org/registry/typedarray/specs/latest/" property="dc:requires"><cite>Typed Array Specification</cite></a>. 26 June 2013. Khronos Working Draft. URL: <a href="https://www.khronos.org/registry/typedarray/specs/latest/" property="dc:requires">https://www.khronos.org/registry/typedarray/specs/latest/</a>
 </dd><dt id="bib-WHATWG-STREAMS-API">[WHATWG-STREAMS-API]</dt><dd>Domenic Denicola; Takeshi Yoshino. <a href="https://streams.spec.whatwg.org/" property="dc:requires"><cite>WHATWG Streams API</cite></a>. URL: <a href="https://streams.spec.whatwg.org/" property="dc:requires">https://streams.spec.whatwg.org/</a>
 </dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
-</dd><dt id="bib-MSE-REGISTRY">[MSE-REGISTRY]</dt><dd>Aaron Colwell. <a href="byte-stream-format-registry.html" property="dc:references"><cite>Media Source Extensions Byte Stream Format Registry</cite></a>. URL: <a href="byte-stream-format-registry.html" property="dc:references">byte-stream-format-registry.html</a>
+</dd><dt id="bib-MSE-REGISTRY">[MSE-REGISTRY]</dt><dd>Matthew Wolenetz; Jerry Smith; Aaron Colwell. <a href="byte-stream-format-registry.html" property="dc:references"><cite>Media Source Extensions Byte Stream Format Registry</cite></a>. URL: <a href="byte-stream-format-registry.html" property="dc:references">byte-stream-format-registry.html</a>
 </dd></dl></section></section><p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>

--- a/isobmff-byte-stream-format-respec.html
+++ b/isobmff-byte-stream-format-respec.html
@@ -36,9 +36,11 @@
       // editors, add as many as you like
       // only "name" is required
       editors:  [
-        { name: "Aaron Colwell",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
-        { name: "Adrian Bateman", url: "", company: "Microsoft Corporation", companyURL: "http://www.microsoft.com/" },
+        { name: "Matthew Wolenetz",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
+        { name: "Jerry Smith", url: "", company: "Microsoft Corporation", companyURL: "http://www.microsoft.com/" },
         { name: "Mark Watson", url: "", company: "Netflix Inc.", companyURL: "http://www.netflix.com/" },
+        { name: "Aaron Colwell (until April 2015)",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
+        { name: "Adrian Bateman (until April 2015)", url: "", company: "Microsoft Corporation", companyURL: "http://www.microsoft.com/" },
       ],
 
       mseDefGroupName: "isobmff-byte-stream-format",
@@ -57,7 +59,7 @@
       ],
 
       // name of the WG
-      wg:           "HTML Working Group",
+      wg:           "HTML Media Extensions Working Group",
 
       // URI of the public WG page
       wgURI:        "http://www.w3.org/html/wg/",
@@ -125,38 +127,38 @@
     <section id="mime-parameters">
       <h2>MIME-type parameters</h2>
       <p>This section specifies the parameters that can be used in the MIME-type passed to <a def-id="isTypeSupported"></a> or <a def-id="addSourceBuffer"></a>.</p>
-      <p>MIME-types for this specification must conform to the rules outlined for "audio/mp4" and "video/mp4" in <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
+      <p>MIME-types for this specification MUST conform to the rules outlined for "audio/mp4" and "video/mp4" in <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
       </p>
-      <div class="note">Implementations may only implement a subset of the codecs and profiles mentioned in the RFC.</div>
+      <div class="note">Implementations MAY only implement a subset of the codecs and profiles mentioned in the RFC.</div>
     </section>
 
     <section id="iso-init-segments">
       <h4>Initialization Segments</h4>
       <p>An ISO BMFF <a def-id="init-segment"></a> is defined in this specification as a single File Type Box (<span class="iso-box">ftyp</span>) followed by a single Movie Box (<span class="iso-box">moov</span>).</p>
 
-      <p>The user agent must run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
+      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
       <ol>
         <li>A File Type Box contains a <span class="iso-var">major_brand</span> or <span class="iso-var">compatible_brand</span> that the user agent does not support.</li>
         <li>A box or field in the Movie Box is encountered that violates the requirements mandated
           by the <span class="iso-var">major_brand</span> or one of the
           <span class="iso-var">compatible_brands</span> in the File Type Box.</li>
-        <li>The tracks in the Movie Box contain samples (i.e. the <span class="iso-var">entry_count</span> in the
+        <li>The tracks in the Movie Box contain samples (i.e., the <span class="iso-var">entry_count</span> in the
           <span class="iso-box">stts</span>, <span class="iso-box">stsc</span> or <span class="iso-box">stco</span> boxes are not set to zero).</li>
         <li>A Movie Extends (<span class="iso-box">mvex</span>) box is not contained in the Movie (<span class="iso-box">moov</span>) box to indicate that Movie Fragments are to be expected.</li>
       </ol>
-      <p>The user agent must support setting the offset from media composition time to movie presentation time by handling an Edit Box (<span class="iso-box">edts</span>) containing a single Edit List Box
-        (<span class="iso-box">elst</span>) that contains a single edit with media rate one. This edit may have a duration of 0 (indicating that it spans all subsequent media) or may have a non-zero duration
+      <p>The user agent MUST support setting the offset from media composition time to movie presentation time by handling an Edit Box (<span class="iso-box">edts</span>) containing a single Edit List Box
+        (<span class="iso-box">elst</span>) that contains a single edit with media rate one. This edit MAY have a duration of 0 (indicating that it spans all subsequent media) or MAY have a non-zero duration
         (indicating the total duration of the movie including fragments).</p>
 
-      <p>The user agent must support parameter sets (e.g., PPS/SPS) stored in the sample entry (as defined for avc1/avc2), and should support parameter
+      <p>The user agent MUST support parameter sets (e.g., PPS/SPS) stored in the sample entry (as defined for avc1/avc2), and SHOULD support parameter
         sets stored inband in the samples themselves (as defined for avc3/avc4).</p>
       <p class="note">For maximum content interoperability, user agents are strongly advised to support both inband and out-of-band storage of the SPS and PPS.</p>
 
       <p>Valid top-level boxes such as <span class="iso-box">pdin</span>, <span class="iso-box">free</span>, and <span class="iso-box">sidx</span> are
-        allowed to appear before the <span class="iso-box">moov</span> box. These boxes must be accepted and ignored by the user agent and are not
+        allowed to appear before the <span class="iso-box">moov</span> box. These boxes MUST be accepted and ignored by the user agent and are not
         considered part of the <a def-id="init-segment"></a> in this specification.</p>
 
-      <p>The user agent must source attribute values for id, kind, label and language for <a def-id="audio-track"></a>, <a def-id="video-track"></a> and
+      <p>The user agent MUST source attribute values for id, kind, label and language for <a def-id="audio-track"></a>, <a def-id="video-track"></a> and
         <a def-id="text-track"></a> objects as described for MPEG-4 ISOBMFF in the in-band tracks spec [[INBANDTRACKS]].</p>
     </section>
 
@@ -165,16 +167,16 @@
       <p>An ISO BMFF <a def-id="media-segment"></a> is defined in this specification as one optional
         Segment Type Box (<span class="iso-box">styp</span>) followed by a single Movie Fragment Box
         (<span class="iso-box">moof</span>) followed by one or more Media Data Boxes (<span class="iso-box">mdat</span>). 
-        If the Segment Type Box is not present, the segment must conform to the brands listed in the
+        If the Segment Type Box is not present, the segment MUST conform to the brands listed in the
         File Type Box (<span class="iso-box">ftyp</span>) in the <a def-id="init-segment"></a>.</p>
       <p>Valid top-level boxes defined in <a def-id="iso-14496-12"></a> other than <span class="iso-box">ftyp</span>,
         <span class="iso-box">moov</span>, <span class="iso-box">styp</span>, <span class="iso-box">moof</span>, and <span class="iso-box">mdat</span> are allowed to appear between the end of an
         <a def-id="init-segment"></a> or <a def-id="media-segment"></a> and before the beginning of a new <a def-id="media-segment"></a>.
-        These boxes must be accepted and ignored by the user agent and are not considered part of the <a def-id="media-segment"></a> in this
+        These boxes MUST be accepted and ignored by the user agent and are not considered part of the <a def-id="media-segment"></a> in this
         specification.
       </p>
 
-      <p>The user agent must run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
+      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
       <ol>
         <li>A box or field in the Movie Fragment Box is encountered that violates the requirements mandated
           by the <span class="iso-var">major_brand</span> or one of the
@@ -209,6 +211,8 @@
       <p>A <a def-id="random-access-point"></a> as defined in this specification corresponds to a Stream Access Point of type 1 or 2 as defined in Annex I of <a def-id="iso-14496-12"></a>.</p>
     </section>
 
+    <section id="conformance"></section>
+
     <section id="acknowledgements">
       <h2>Acknowledgments</h2>
       The editors would like to thank <a def-id="contributors"></a> for their contributions to this specification.
@@ -225,7 +229,15 @@
         </thead>
         <tbody>
           <tr>
-            <td>20 March 2015</td>
+            <td>20 July 2016</td>
+            <td>
+              <ul>
+                <li>Issue 115 - Updated editors and updated to use RFC2119 key word mark-up and reference.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td><a href="https://rawgit.com/w3c/media-source/ec35e38422eb1a5f114cffb61ddf6ea99acf6985/isobmff-byte-stream-format.html">20 March 2015</a></td>
             <td>
               <ul>
                 <li>Bug 28066 - Changed Movie Header Box to Movie Box.</li>

--- a/isobmff-byte-stream-format.html
+++ b/isobmff-byte-stream-format.html
@@ -15,40 +15,40 @@
     <meta name="bug.component" content="Media Source Extensions">
 
     <style>/* --- ISSUES/NOTES --- */
-div.issue-title, div.note-title , div.warning-title {
+div.issue-title, div.note-title , div.ednote-title, div.warning-title {
     padding-right:  1em;
     min-width: 7.5em;
     color: #b9ab2d;
 }
 div.issue-title { color: #e05252; }
-div.note-title { color: #2b2; }
+div.note-title, div.ednote-title { color: #2b2; }
 div.warning-title { color: #f22; }
-div.issue-title span, div.note-title span, div.warning-title span {
+div.issue-title span, div.note-title span, div.ednote-title span, div.warning-title span {
     text-transform: uppercase;
 }
-div.note, div.issue, div.warning {
+div.note, div.issue, div.ednote, div.warning {
     margin-top: 1em;
     margin-bottom: 1em;
 }
-.note > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
-.issue, .note, .warning {
+.note > p:first-child, .ednote > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
+.issue, .note, .ednote, .warning {
     padding: .5em;
     border-left-width: .5em;
     border-left-style: solid;
 }
-div.issue, div.note , div.warning {
+div.issue, div.note , div.ednote,  div.warning {
     padding: 1em 1.2em 0.5em;
     margin: 1em 0;
     position: relative;
     clear: both;
 }
-span.note, span.issue, span.warning { padding: .1em .5em .15em; }
+span.note, span.ednote, span.issue, span.warning { padding: .1em .5em .15em; }
 
 .issue {
     border-color: #e05252;
     background: #fbe9e9;
 }
-.note {
+.note, .ednote {
     border-color: #52e052;
     background: #e9fbe9;
 }
@@ -70,6 +70,15 @@ span.note, span.issue, span.warning { padding: .1em .5em .15em; }
     padding-right: .3em;
     vertical-align: top;
     margin-top: -0.5em;
+}
+
+li.task-list-item {
+    list-style: none;
+}
+
+input.task-list-item-checkbox {
+    margin: 0 0.35em 0.25em -1.6em;
+    vertical-align: middle;
 }
 </style><link rel="stylesheet" href="mse.css">
     <style>
@@ -192,18 +201,101 @@ table.simple {
         display: none;
     }
 }
-</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--></head>
+</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
+  "specStatus": "ED",
+  "shortName": "",
+  "edDraftURI": "https://w3c.github.io/media-source/isobmff-byte-stream-format.html",
+  "prevVersion": "http://www.w3.org/2013/12/byte-stream-format-registry/isobmff-byte-stream-format.html",
+  "editors": [
+    {
+      "name": "Matthew Wolenetz",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    },
+    {
+      "name": "Jerry Smith",
+      "url": "",
+      "company": "Microsoft Corporation",
+      "companyURL": "http://www.microsoft.com/"
+    },
+    {
+      "name": "Mark Watson",
+      "url": "",
+      "company": "Netflix Inc.",
+      "companyURL": "http://www.netflix.com/"
+    },
+    {
+      "name": "Aaron Colwell (until April 2015)",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    },
+    {
+      "name": "Adrian Bateman (until April 2015)",
+      "url": "",
+      "company": "Microsoft Corporation",
+      "companyURL": "http://www.microsoft.com/"
+    }
+  ],
+  "mseDefGroupName": "isobmff-byte-stream-format",
+  "mseUnusedGroupNameExcludeList": [
+    "media-source"
+  ],
+  "mseContributors": [
+    "Chris Poole",
+    "Cyril Concolato",
+    "David Singer",
+    "Jer Noble",
+    "Jerry Smith",
+    "Joe Steele",
+    "John Simmons",
+    "Kevin Streeter",
+    "Michael Thornburgh",
+    "Steven Robertson"
+  ],
+  "wg": "HTML Media Extensions Working Group",
+  "wgURI": "http://www.w3.org/html/wg/",
+  "wgPublicList": "public-html-media",
+  "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/40318/status",
+  "noIDLIn": true,
+  "scheme": "https",
+  "preProcess": [
+    null
+  ],
+  "definitionMap": {
+    "movie-fragment relative addressing": [
+      "movie-fragment-relative-addressing"
+    ]
+  },
+  "postProcess": [
+    null
+  ],
+  "localBiblio": {
+    "INBANDTRACKS": {
+      "title": "Sourcing In-band Media Resource Tracks from Media Containers into HTML",
+      "href": "http://dev.w3.org/html5/html-sourcing-inband-tracks/",
+      "authors": [
+        "Bob Lund",
+        "Silvia Pfeiffer"
+      ],
+      "publisher": "W3C"
+    }
+  }
+}</script></head>
   <body class="h-entry" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
   <p>
       
         
-            <a href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/Icons/w3c_home" alt="W3C"></a>
+            <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/Icons/w3c_home" alt="W3C"></a>
+            
+            
         
       
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">ISO BMFF Byte Stream Format</h1>
   
-  <h2 id="w3c-editor-s-draft-20-march-2015"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2015-03-20">20 March 2015</time></h2>
+  <h2 id="w3c-editor-s-draft-12-july-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-07-12">12 July 2016</time></h2>
   <dl>
     
       <dt>This version:</dt>
@@ -224,13 +316,19 @@ table.simple {
     
     
     <dt>Editors:</dt>
-    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Matthew Wolenetz</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
 <span property="rdf:rest" resource="_:editor1"></span>
 </dd>
-<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Adrian Bateman</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
+<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Jerry Smith</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
 <span property="rdf:rest" resource="_:editor2"></span>
 </dd>
 <dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Mark Watson</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.netflix.com/">Netflix Inc.</a></span>
+<span property="rdf:rest" resource="_:editor3"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor3"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+<span property="rdf:rest" resource="_:editor4"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor4"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Adrian Bateman (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
 <span property="rdf:rest" resource="rdf:nil"></span>
 </dd>
 
@@ -244,7 +342,7 @@ table.simple {
     
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2015
+        2016
         
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
@@ -254,13 +352,15 @@ table.simple {
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
         
-          <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+          
+            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+          
         
         rules apply.
       </p>
     
   
-  <hr>
+  <hr title="Separator for header">
 </div>
     <section id="abstract" class="introductory" property="dc:abstract"><h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2><p>
       This specification defines a <a href="http://www.w3.org/TR/media-source/">Media Source Extensions</a> byte stream format specification based on the ISO Base Media
@@ -270,75 +370,82 @@ table.simple {
     
       
         <p>
-          <em>This section describes the status of this document at the time of its publication.
-          Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the
-          latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at
-          http://www.w3.org/TR/.</em>
+          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
         </p>
         
-        
-        
-        <p>
-          This document was published by the <a href="http://www.w3.org/html/wg/">HTML Working Group</a> as an Editor's Draft.
-          
-          
-            If you wish to make comments regarding this document, please send them to 
-            <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a> 
-            (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
-            <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
           
           
           
           
-          
-            
-            All comments are welcome.
-            
-          
-        </p>
-        
-        
-        
           <p>
-            Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
-            Membership. This is a draft document and may be updated, replaced or obsoleted by other
-            documents at any time. It is inappropriate to cite this document as other than work in
-            progress.
-          </p>
-        
-        
-        
-        <p>
-          
-            This document was produced by a group operating under the 
-            <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
-            Policy</a>.
-          
-          
-          
+            This document was published by the <a href="http://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft.
             
-              <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
-              disclosures</a> 
             
-            made in connection with the deliverables of the group; that page also includes
-            instructions for disclosing a patent. An individual who has actual knowledge of a patent
-            which the individual believes contains
-            <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-            Claim(s)</a> must disclose the information in accordance with
-            <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-            6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-          
-          
-        </p>
-        
-          <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+              If you wish to make comments regarding this document, please send them to
+              <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>
+              (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
+              <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
+            
+            
+            
+            
+            
+              
+              All comments are welcome.
+              
+            
           </p>
-        
+          
+          
+          
+          
+            <p>
+              Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
+              Membership. This is a draft document and may be updated, replaced or obsoleted by other
+              documents at any time. It is inappropriate to cite this document as other than work in
+              progress.
+            </p>
+          
+          
+          
+          <p>
+            
+              This document was produced by
+              
+              a group
+               operating under the
+              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+              Policy</a>.
+            
+            
+            
+              
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
+                disclosures</a>
+              
+              made in connection with the deliverables of
+              
+              the group; that page also includes
+              
+              instructions for disclosing a patent. An individual who has actual knowledge of a patent
+              which the individual believes contains
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+              Claim(s)</a> must disclose the information in accordance with
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+            
+            
+          </p>
+          
+            <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+            </p>
+          
+          
         
       
     
   
-</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory" id="respecContents"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#mime-parameters" class="tocxref"><span class="secno">2. </span>MIME-type parameters</a></li><li class="tocline"><a href="#iso-init-segments" class="tocxref"><span class="secno">3. </span>Initialization Segments</a></li><li class="tocline"><a href="#iso-media-segments" class="tocxref"><span class="secno">4. </span>Media Segments</a></li><li class="tocline"><a href="#iso-random-access-points" class="tocxref"><span class="secno">5. </span>Random Access Points</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">6. </span>Acknowledgments</a></li><li class="tocline"><a href="#revision-history" class="tocxref"><span class="secno">7. </span>Revision History</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">A.1 </span>Informative references</a></li></ul></li></ul></section>
+</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#mime-parameters" class="tocxref"><span class="secno">2. </span>MIME-type parameters</a></li><li class="tocline"><a href="#iso-init-segments" class="tocxref"><span class="secno">3. </span>Initialization Segments</a></li><li class="tocline"><a href="#iso-media-segments" class="tocxref"><span class="secno">4. </span>Media Segments</a></li><li class="tocline"><a href="#iso-random-access-points" class="tocxref"><span class="secno">5. </span>Random Access Points</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">6. </span>Conformance</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">7. </span>Acknowledgments</a></li><li class="tocline"><a href="#revision-history" class="tocxref"><span class="secno">8. </span>Revision History</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">A.2 </span>Informative references</a></li></ul></li></ul></section>
 
     <section id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
@@ -351,39 +458,39 @@ table.simple {
     <section id="mime-parameters" typeof="bibo:Chapter" resource="#mime-parameters" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mime-parameters" resource="#h-mime-parameters"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>MIME-type parameters</span></h2>
       <p>This section specifies the parameters that can be used in the MIME-type passed to <code><a href="index.html#widl-MediaSource-isTypeSupported-boolean-DOMString-type">isTypeSupported()</a></code> or <code><a href="index.html#widl-MediaSource-addSourceBuffer-SourceBuffer-DOMString-type">addSourceBuffer()</a></code>.</p>
-      <p>MIME-types for this specification must conform to the rules outlined for "audio/mp4" and "video/mp4" in <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
+      <p>MIME-types for this specification <em class="rfc2119" title="MUST">MUST</em> conform to the rules outlined for "audio/mp4" and "video/mp4" in <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
       </p>
-      <div class="note"><div class="note-title" aria-level="3" role="heading" id="h-note1"><span>Note</span></div><div class="">Implementations may only implement a subset of the codecs and profiles mentioned in the RFC.</div></div>
+      <div class="note"><div class="note-title" aria-level="3" role="heading" id="h-note1"><span>Note</span></div><div class="">Implementations <em class="rfc2119" title="MAY">MAY</em> only implement a subset of the codecs and profiles mentioned in the RFC.</div></div>
     </section>
 
     <section id="iso-init-segments" typeof="bibo:Chapter" resource="#iso-init-segments" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-iso-init-segments" resource="#h-iso-init-segments"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Initialization Segments</span></h2>
       <p>An ISO BMFF <a href="index.html#init-segment">initialization segment</a> is defined in this specification as a single File Type Box (<span class="iso-box">ftyp</span>) followed by a single Movie Box (<span class="iso-box">moov</span>).</p>
 
-      <p>The user agent must run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
       <ol>
         <li>A File Type Box contains a <span class="iso-var">major_brand</span> or <span class="iso-var">compatible_brand</span> that the user agent does not support.</li>
         <li>A box or field in the Movie Box is encountered that violates the requirements mandated
           by the <span class="iso-var">major_brand</span> or one of the
           <span class="iso-var">compatible_brands</span> in the File Type Box.</li>
-        <li>The tracks in the Movie Box contain samples (i.e. the <span class="iso-var">entry_count</span> in the
+        <li>The tracks in the Movie Box contain samples (i.e., the <span class="iso-var">entry_count</span> in the
           <span class="iso-box">stts</span>, <span class="iso-box">stsc</span> or <span class="iso-box">stco</span> boxes are not set to zero).</li>
         <li>A Movie Extends (<span class="iso-box">mvex</span>) box is not contained in the Movie (<span class="iso-box">moov</span>) box to indicate that Movie Fragments are to be expected.</li>
       </ol>
-      <p>The user agent must support setting the offset from media composition time to movie presentation time by handling an Edit Box (<span class="iso-box">edts</span>) containing a single Edit List Box
-        (<span class="iso-box">elst</span>) that contains a single edit with media rate one. This edit may have a duration of 0 (indicating that it spans all subsequent media) or may have a non-zero duration
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> support setting the offset from media composition time to movie presentation time by handling an Edit Box (<span class="iso-box">edts</span>) containing a single Edit List Box
+        (<span class="iso-box">elst</span>) that contains a single edit with media rate one. This edit <em class="rfc2119" title="MAY">MAY</em> have a duration of 0 (indicating that it spans all subsequent media) or <em class="rfc2119" title="MAY">MAY</em> have a non-zero duration
         (indicating the total duration of the movie including fragments).</p>
 
-      <p>The user agent must support parameter sets (e.g., PPS/SPS) stored in the sample entry (as defined for avc1/avc2), and should support parameter
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> support parameter sets (e.g., PPS/SPS) stored in the sample entry (as defined for avc1/avc2), and <em class="rfc2119" title="SHOULD">SHOULD</em> support parameter
         sets stored inband in the samples themselves (as defined for avc3/avc4).</p>
       <div class="note"><div class="note-title" aria-level="3" role="heading" id="h-note2"><span>Note</span></div><p class="">For maximum content interoperability, user agents are strongly advised to support both inband and out-of-band storage of the SPS and PPS.</p></div>
 
       <p>Valid top-level boxes such as <span class="iso-box">pdin</span>, <span class="iso-box">free</span>, and <span class="iso-box">sidx</span> are
-        allowed to appear before the <span class="iso-box">moov</span> box. These boxes must be accepted and ignored by the user agent and are not
+        allowed to appear before the <span class="iso-box">moov</span> box. These boxes <em class="rfc2119" title="MUST">MUST</em> be accepted and ignored by the user agent and are not
         considered part of the <a href="index.html#init-segment">initialization segment</a> in this specification.</p>
 
-      <p>The user agent must source attribute values for id, kind, label and language for <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#audiotrack">AudioTrack</a></code>, <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#videotrack">VideoTrack</a></code> and
-        <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#texttrack">TextTrack</a></code> objects as described for MPEG-4 ISOBMFF in the in-band tracks spec [<cite><a class="bibref" href="#bib-INBANDTRACKS">INBANDTRACKS</a></cite>].</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> source attribute values for id, kind, label and language for <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code>, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> and
+        <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> objects as described for MPEG-4 ISOBMFF in the in-band tracks spec [<cite><a class="bibref" href="#bib-INBANDTRACKS">INBANDTRACKS</a></cite>].</p>
     </section>
 
     <section id="iso-media-segments" typeof="bibo:Chapter" resource="#iso-media-segments" property="bibo:hasPart">
@@ -391,16 +498,16 @@ table.simple {
       <p>An ISO BMFF <a href="index.html#media-segment">media segment</a> is defined in this specification as one optional
         Segment Type Box (<span class="iso-box">styp</span>) followed by a single Movie Fragment Box
         (<span class="iso-box">moof</span>) followed by one or more Media Data Boxes (<span class="iso-box">mdat</span>). 
-        If the Segment Type Box is not present, the segment must conform to the brands listed in the
+        If the Segment Type Box is not present, the segment <em class="rfc2119" title="MUST">MUST</em> conform to the brands listed in the
         File Type Box (<span class="iso-box">ftyp</span>) in the <a href="index.html#init-segment">initialization segment</a>.</p>
       <p>Valid top-level boxes defined in <a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c061988_ISO_IEC_14496-12_2012.zip">ISO/IEC 14496-12</a> other than <span class="iso-box">ftyp</span>,
         <span class="iso-box">moov</span>, <span class="iso-box">styp</span>, <span class="iso-box">moof</span>, and <span class="iso-box">mdat</span> are allowed to appear between the end of an
         <a href="index.html#init-segment">initialization segment</a> or <a href="index.html#media-segment">media segment</a> and before the beginning of a new <a href="index.html#media-segment">media segment</a>.
-        These boxes must be accepted and ignored by the user agent and are not considered part of the <a href="index.html#media-segment">media segment</a> in this
+        These boxes <em class="rfc2119" title="MUST">MUST</em> be accepted and ignored by the user agent and are not considered part of the <a href="index.html#media-segment">media segment</a> in this
         specification.
       </p>
 
-      <p>The user agent must run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
       <ol>
         <li>A box or field in the Movie Fragment Box is encountered that violates the requirements mandated
           by the <span class="iso-var">major_brand</span> or one of the
@@ -417,7 +524,7 @@ table.simple {
 	<li>Inband parameter sets are not present in the appropriate samples and parameter sets are not present in the last initialization segment appended.</li>
       </ol>
 
-      <p>A Movie Fragment Box uses <dfn id="movie-fragment-relative-addressing">movie-fragment relative addressing</dfn> 
+      <p>A Movie Fragment Box uses <dfn id="movie-fragment-relative-addressing" data-dfn-type="dfn">movie-fragment relative addressing</dfn> 
         when the first Track Fragment Run(<span class="iso-box">trun</span>) box in each Track Fragment Box
         has the <span class="iso-var">data-offset-present</span> flag set and either of the following
         conditions are met:</p>
@@ -435,13 +542,24 @@ table.simple {
       <p>A <a href="index.html#random-access-point">random access point</a> as defined in this specification corresponds to a Stream Access Point of type 1 or 2 as defined in Annex I of <a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c061988_ISO_IEC_14496-12_2012.zip">ISO/IEC 14496-12</a>.</p>
     </section>
 
+    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart"><!--OddPage--><h2 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Conformance</span></h2>
+<p>
+  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
+  and notes in this specification are non-normative. Everything else in this specification is
+  normative.
+</p>
+<p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are 
+  to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+</p>
+</section>
+
     <section id="acknowledgements" typeof="bibo:Chapter" resource="#acknowledgements" property="bibo:hasPart">
-      <!--OddPage--><h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Acknowledgments</span></h2>
+      <!--OddPage--><h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Acknowledgments</span></h2>
       The editors would like to thank Chris Poole, Cyril Concolato, David Singer, Jer Noble, Jerry Smith, Joe Steele, John Simmons, Kevin Streeter, Michael Thornburgh, and Steven Robertson for their contributions to this specification.
     </section>
 
     <section id="revision-history" typeof="bibo:Chapter" resource="#revision-history" property="bibo:hasPart">
-      <!--OddPage--><h2 id="h-revision-history" resource="#h-revision-history"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Revision History</span></h2>
+      <!--OddPage--><h2 id="h-revision-history" resource="#h-revision-history"><span property="xhv:role" resource="xhv:heading"><span class="secno">8. </span>Revision History</span></h2>
       <table class="old-table">
         <thead>
           <tr>
@@ -451,7 +569,15 @@ table.simple {
         </thead>
         <tbody>
           <tr>
-            <td>20 March 2015</td>
+            <td>12 July 2016</td>
+            <td>
+              <ul>
+                <li>Issue 115 - Updated editors and updated to use RFC2119 key word mark-up and reference.</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td><a href="https://rawgit.com/w3c/media-source/ec35e38422eb1a5f114cffb61ddf6ea99acf6985/isobmff-byte-stream-format.html">20 March 2015</a></td>
             <td>
               <ul>
                 <li>Bug 28066 - Changed Movie Header Box to Movie Box.</li>
@@ -491,5 +617,6 @@ table.simple {
       </table>
   
 
-</section><form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
+</section><form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+</dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
 </dd></dl></section></section></body></html>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -153,7 +153,7 @@
               title: "Media Source Extensions Byte Stream Format Registry",
               href: "byte-stream-format-registry.html",
               //href: "http://www.w3.org/2013/12/byte-stream-format-registry/",
-              authors: ["Aaron Colwell"],
+              authors: ["Matthew Wolenetz", "Jerry Smith", "Aaron Colwell"],
               publisher: "W3C",
           },
           "INBANDTRACKS": {
@@ -2828,6 +2828,7 @@
             <td>
               <ul>
                 <li>Issue 59 - Correct i.e. and e.g. style.</li>
+                <li>Issue 115 - Updated byte stream format registry editors in localbiblio.</li>
               </ul>
             </td>
           </tr>

--- a/mp2t-byte-stream-format-respec.html
+++ b/mp2t-byte-stream-format-respec.html
@@ -37,9 +37,11 @@
       // editors, add as many as you like
       // only "name" is required
       editors:  [
-        { name: "Aaron Colwell",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
-        { name: "Adrian Bateman", url: "", company: "Microsoft Corporation", companyURL: "http://www.microsoft.com/" },
+        { name: "Matthew Wolenetz",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
+        { name: "Jerry Smith", url: "", company: "Microsoft Corporation", companyURL: "http://www.microsoft.com/" },
         { name: "Mark Watson", url: "", company: "Netflix Inc.", companyURL: "http://www.netflix.com/" },
+        { name: "Aaron Colwell (until April 2015)",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
+        { name: "Adrian Bateman (until April 2015)", url: "", company: "Microsoft Corporation", companyURL: "http://www.microsoft.com/" },
       ],
 
       mseDefGroupName: "mp2t-byte-stream-format",
@@ -55,7 +57,7 @@
       ],
 
       // name of the WG
-      wg:           "HTML Working Group",
+      wg:           "HTML Media Extensions Working Group",
 
       // URI of the public WG page
       wgURI:        "http://www.w3.org/html/wg/",
@@ -120,25 +122,25 @@
 
     <section id="mime-parameters">
       <h2>MIME-type info</h2>
-      <p>The MIME-type/subtype pair of "video/MP2T", as specified in <a href="http://tools.ietf.org/html/rfc3551">RFC 3551</a>, must be used for byte streams that conform
+      <p>The MIME-type/subtype pair of "video/MP2T", as specified in <a href="http://tools.ietf.org/html/rfc3551">RFC 3551</a>, MUST be used for byte streams that conform
         to this specification.</p>
 
       <p>This following parameters can be used in the MIME-type passed to <a def-id="isTypeSupported"></a> or <a def-id="addSourceBuffer"></a>.</p>
       <dl>
         <dt>codecs</dt>
         <dd>
-          A comma separated list of codec IDs used to specify what codecs will be used in the byte stream. Implementations should accept IDs in the form specified by
+          A comma separated list of codec IDs used to specify what codecs will be used in the byte stream. Implementations SHOULD accept IDs in the form specified by
           <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
-          <div class="note">Implementations may only implement a subset of the codecs and profiles mentioned in the RFC.</div>
+          <div class="note">Implementations MAY only implement a subset of the codecs and profiles mentioned in the RFC.</div>
         </dd>
       </dl>
     </section>
 
     <section id="mpeg2ts-general">
       <h4>General Transport Stream Requirements</h4>
-      <p>MPEG-2 TS media and initialization segments must conform to the MPEG-2 TS Adaptive Profile (ISO/IEC 13818-1:2012 Amd. 2).</p>
+      <p>MPEG-2 TS media and initialization segments MUST conform to the MPEG-2 TS Adaptive Profile (ISO/IEC 13818-1:2012 Amd. 2).</p>
 
-      <p>The user agent must run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
+      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
       <ol>
         <li>Segments do not contain complete MPEG-2 TS packets.</li>
         <li>Segments do not contain complete PES packets and sections.</li>
@@ -149,21 +151,21 @@
     <section id="mpeg2ts-init-segments">
       <h4>Initialization Segments</h4>
       <p>An MPEG-2 TS initialization segment consists of a single PAT and a single PMT.</p>
-      <p>The user agent must run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
+      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
       <ol>
         <li>A PAT is not present in the <a def-id="init-segment"></a></li>
         <li>A PMT is not present in the <a def-id="init-segment"></a></li>
       </ol>
 
-      <p>The user agent must accept and ignore other SI, such as CAT, that are invariant for all subsequent media segments.</p>
-      <p>The user agent must source attribute values for id, kind, label and language for <a def-id="audio-track"></a>, <a def-id="video-track"></a> and
+      <p>The user agent MUST accept and ignore other SI, such as CAT, that are invariant for all subsequent media segments.</p>
+      <p>The user agent MUST source attribute values for id, kind, label and language for <a def-id="audio-track"></a>, <a def-id="video-track"></a> and
         <a def-id="text-track"></a> objects as described for MPEG-2 Transport Streams in the in-band tracks spec [[INBANDTRACKS]].</p>
     </section>
 
     <section id="mpeg2ts-media-segments">
       <h4>Media Segments</h4>
 
-      <p>The user agent must run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
+      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are met:</p>
       <ol>
         <li>A media segment relies on initialization information in another media segment.</li>
         <li>At least one PES packet does not have a PTS timestamp.</li>
@@ -180,10 +182,10 @@
     </section>
     <section id="mpeg2ts-discontinuities">
       <h4>Timestamp Rollover &amp; Discontinuities</h4>
-      <p>Timestamp rollovers and discontinuities must be handled by the UA. The UA's MPEG-2 TS implementation must maintain an internal offset
+      <p>Timestamp rollovers and discontinuities MUST be handled by the UA. The UA's MPEG-2 TS implementation MUST maintain an internal offset
         variable, <dfn id="mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</dfn>, to keep track of the offset that needs to be applied to timestamps
         that have rolled over or are part of a discontinuity. <var>MPEG2TS_timestampOffset</var> is initially set to 0 when the <a class="externalDFN">SourceBuffer</a> is
-        created.  This offset must be applied to the timestamps as part of the conversion process from MPEG-2 TS packets
+        created.  This offset MUST be applied to the timestamps as part of the conversion process from MPEG-2 TS packets
         into <a def-id="coded-frames"></a> for the <a def-id="coded-frame-processing-algorithm"></a>. This results in the coded frame timestamps
         for a packet being computed by the following equations:</p>
       <pre>
@@ -192,13 +194,15 @@
 
       <p><a def-id="mpeg2ts-timestampOffset"></a> is updated in the following ways:</p>
       <ul>
-        <li>Each time a timestamp rollover is detected, 2^33 must be added to <a def-id="mpeg2ts-timestampOffset"></a>.</li>
-        <li>When a discontinuity is detected, <a def-id="mpeg2ts-timestampOffset"></a> must be adjusted to make the timestamps after the discontinuity appear
+        <li>Each time a timestamp rollover is detected, 2^33 MUST be added to <a def-id="mpeg2ts-timestampOffset"></a>.</li>
+        <li>When a discontinuity is detected, <a def-id="mpeg2ts-timestampOffset"></a> MUST be adjusted to make the timestamps after the discontinuity appear
           to come immediately after the timestamps before the discontinuity.</li>
-        <li>When <a def-id="abort"></a> is called, <a def-id="mpeg2ts-timestampOffset"></a> must be set to 0.</li>
-        <li>When <a def-id="timestampOffset"></a> is successfully set, <a def-id="mpeg2ts-timestampOffset"></a> must be set to 0.</li>
+        <li>When <a def-id="abort"></a> is called, <a def-id="mpeg2ts-timestampOffset"></a> MUST be set to 0.</li>
+        <li>When <a def-id="timestampOffset"></a> is successfully set, <a def-id="mpeg2ts-timestampOffset"></a> MUST be set to 0.</li>
       </ul>
     </section>
+
+    <section id="conformance"></section>
 
     <section id="acknowledgements">
       <h2>Acknowledgments</h2>

--- a/mp2t-byte-stream-format.html
+++ b/mp2t-byte-stream-format.html
@@ -15,40 +15,40 @@
     <meta name="bug.component" content="Media Source Extensions">
 
     <style>/* --- ISSUES/NOTES --- */
-div.issue-title, div.note-title , div.warning-title {
+div.issue-title, div.note-title , div.ednote-title, div.warning-title {
     padding-right:  1em;
     min-width: 7.5em;
     color: #b9ab2d;
 }
 div.issue-title { color: #e05252; }
-div.note-title { color: #2b2; }
+div.note-title, div.ednote-title { color: #2b2; }
 div.warning-title { color: #f22; }
-div.issue-title span, div.note-title span, div.warning-title span {
+div.issue-title span, div.note-title span, div.ednote-title span, div.warning-title span {
     text-transform: uppercase;
 }
-div.note, div.issue, div.warning {
+div.note, div.issue, div.ednote, div.warning {
     margin-top: 1em;
     margin-bottom: 1em;
 }
-.note > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
-.issue, .note, .warning {
+.note > p:first-child, .ednote > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
+.issue, .note, .ednote, .warning {
     padding: .5em;
     border-left-width: .5em;
     border-left-style: solid;
 }
-div.issue, div.note , div.warning {
+div.issue, div.note , div.ednote,  div.warning {
     padding: 1em 1.2em 0.5em;
     margin: 1em 0;
     position: relative;
     clear: both;
 }
-span.note, span.issue, span.warning { padding: .1em .5em .15em; }
+span.note, span.ednote, span.issue, span.warning { padding: .1em .5em .15em; }
 
 .issue {
     border-color: #e05252;
     background: #fbe9e9;
 }
-.note {
+.note, .ednote {
     border-color: #52e052;
     background: #e9fbe9;
 }
@@ -70,6 +70,15 @@ span.note, span.issue, span.warning { padding: .1em .5em .15em; }
     padding-right: .3em;
     vertical-align: top;
     margin-top: -0.5em;
+}
+
+li.task-list-item {
+    list-style: none;
+}
+
+input.task-list-item-checkbox {
+    margin: 0 0.35em 0.25em -1.6em;
+    vertical-align: middle;
 }
 </style><link rel="stylesheet" href="mse.css">
 
@@ -193,13 +202,15 @@ table.simple {
   <p>
       
         
-            <a href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/Icons/w3c_home" alt="W3C"></a>
+            <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/Icons/w3c_home" alt="W3C"></a>
+            
+            
         
       
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">MPEG-2 TS Byte Stream Format</h1>
   
-  <h2 id="w3c-editor-s-draft-09-march-2015"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2015-03-09">09 March 2015</time></h2>
+  <h2 id="w3c-editor-s-draft-20-july-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-07-20">20 July 2016</time></h2>
   <dl>
     
       <dt>This version:</dt>
@@ -220,13 +231,19 @@ table.simple {
     
     
     <dt>Editors:</dt>
-    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Matthew Wolenetz</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
 <span property="rdf:rest" resource="_:editor1"></span>
 </dd>
-<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Adrian Bateman</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
+<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Jerry Smith</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
 <span property="rdf:rest" resource="_:editor2"></span>
 </dd>
 <dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Mark Watson</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.netflix.com/">Netflix Inc.</a></span>
+<span property="rdf:rest" resource="_:editor3"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor3"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+<span property="rdf:rest" resource="_:editor4"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor4"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Adrian Bateman (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
 <span property="rdf:rest" resource="rdf:nil"></span>
 </dd>
 
@@ -240,7 +257,7 @@ table.simple {
     
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2015
+        2016
         
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
@@ -250,13 +267,15 @@ table.simple {
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
         
-          <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+          
+            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+          
         
         rules apply.
       </p>
     
   
-  <hr>
+  <hr title="Separator for header">
 </div>
     <section id="abstract" class="introductory" property="dc:abstract"><h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2><p>
       This specification defines a <a href="http://www.w3.org/TR/media-source/">Media Source Extensions</a> byte stream format specification based on MPEG-2 Transport Streams.
@@ -265,75 +284,82 @@ table.simple {
     
       
         <p>
-          <em>This section describes the status of this document at the time of its publication.
-          Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the
-          latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at
-          http://www.w3.org/TR/.</em>
+          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
         </p>
         
-        
-        
-        <p>
-          This document was published by the <a href="http://www.w3.org/html/wg/">HTML Working Group</a> as an Editor's Draft.
-          
-          
-            If you wish to make comments regarding this document, please send them to 
-            <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a> 
-            (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
-            <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
           
           
           
           
-          
-            
-            All comments are welcome.
-            
-          
-        </p>
-        
-        
-        
           <p>
-            Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
-            Membership. This is a draft document and may be updated, replaced or obsoleted by other
-            documents at any time. It is inappropriate to cite this document as other than work in
-            progress.
-          </p>
-        
-        
-        
-        <p>
-          
-            This document was produced by a group operating under the 
-            <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
-            Policy</a>.
-          
-          
-          
+            This document was published by the <a href="http://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft.
             
-              <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
-              disclosures</a> 
             
-            made in connection with the deliverables of the group; that page also includes
-            instructions for disclosing a patent. An individual who has actual knowledge of a patent
-            which the individual believes contains
-            <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-            Claim(s)</a> must disclose the information in accordance with
-            <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-            6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-          
-          
-        </p>
-        
-          <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+              If you wish to make comments regarding this document, please send them to
+              <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>
+              (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
+              <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
+            
+            
+            
+            
+            
+              
+              All comments are welcome.
+              
+            
           </p>
-        
+          
+          
+          
+          
+            <p>
+              Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
+              Membership. This is a draft document and may be updated, replaced or obsoleted by other
+              documents at any time. It is inappropriate to cite this document as other than work in
+              progress.
+            </p>
+          
+          
+          
+          <p>
+            
+              This document was produced by
+              
+              a group
+               operating under the
+              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+              Policy</a>.
+            
+            
+            
+              
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
+                disclosures</a>
+              
+              made in connection with the deliverables of
+              
+              the group; that page also includes
+              
+              instructions for disclosing a patent. An individual who has actual knowledge of a patent
+              which the individual believes contains
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+              Claim(s)</a> must disclose the information in accordance with
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+            
+            
+          </p>
+          
+            <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+            </p>
+          
+          
         
       
     
   
-</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory" id="respecContents"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#mime-parameters" class="tocxref"><span class="secno">2. </span>MIME-type info</a></li><li class="tocline"><a href="#mpeg2ts-general" class="tocxref"><span class="secno">3. </span>General Transport Stream Requirements</a></li><li class="tocline"><a href="#mpeg2ts-init-segments" class="tocxref"><span class="secno">4. </span>Initialization Segments</a></li><li class="tocline"><a href="#mpeg2ts-media-segments" class="tocxref"><span class="secno">5. </span>Media Segments</a></li><li class="tocline"><a href="#mpeg2ts-random-access-points" class="tocxref"><span class="secno">6. </span>Random Access Points</a></li><li class="tocline"><a href="#mpeg2ts-discontinuities" class="tocxref"><span class="secno">7. </span>Timestamp Rollover &amp; Discontinuities</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">8. </span>Acknowledgments</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">A.1 </span>Informative references</a></li></ul></li></ul></section>
+</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#mime-parameters" class="tocxref"><span class="secno">2. </span>MIME-type info</a></li><li class="tocline"><a href="#mpeg2ts-general" class="tocxref"><span class="secno">3. </span>General Transport Stream Requirements</a></li><li class="tocline"><a href="#mpeg2ts-init-segments" class="tocxref"><span class="secno">4. </span>Initialization Segments</a></li><li class="tocline"><a href="#mpeg2ts-media-segments" class="tocxref"><span class="secno">5. </span>Media Segments</a></li><li class="tocline"><a href="#mpeg2ts-random-access-points" class="tocxref"><span class="secno">6. </span>Random Access Points</a></li><li class="tocline"><a href="#mpeg2ts-discontinuities" class="tocxref"><span class="secno">7. </span>Timestamp Rollover &amp; Discontinuities</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">8. </span>Conformance</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">9. </span>Acknowledgments</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">A.2 </span>Informative references</a></li></ul></li></ul></section>
 
     <section id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
@@ -346,25 +372,25 @@ table.simple {
 
     <section id="mime-parameters" typeof="bibo:Chapter" resource="#mime-parameters" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mime-parameters" resource="#h-mime-parameters"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>MIME-type info</span></h2>
-      <p>The MIME-type/subtype pair of "video/MP2T", as specified in <a href="http://tools.ietf.org/html/rfc3551">RFC 3551</a>, must be used for byte streams that conform
+      <p>The MIME-type/subtype pair of "video/MP2T", as specified in <a href="http://tools.ietf.org/html/rfc3551">RFC 3551</a>, <em class="rfc2119" title="MUST">MUST</em> be used for byte streams that conform
         to this specification.</p>
 
       <p>This following parameters can be used in the MIME-type passed to <code><a href="index.html#widl-MediaSource-isTypeSupported-boolean-DOMString-type">isTypeSupported()</a></code> or <code><a href="index.html#widl-MediaSource-addSourceBuffer-SourceBuffer-DOMString-type">addSourceBuffer()</a></code>.</p>
       <dl>
         <dt>codecs</dt>
         <dd>
-          A comma separated list of codec IDs used to specify what codecs will be used in the byte stream. Implementations should accept IDs in the form specified by
+          A comma separated list of codec IDs used to specify what codecs will be used in the byte stream. Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> accept IDs in the form specified by
           <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
-          <div class="note"><div class="note-title" aria-level="3" role="heading" id="h-note1"><span>Note</span></div><div class="">Implementations may only implement a subset of the codecs and profiles mentioned in the RFC.</div></div>
+          <div class="note"><div class="note-title" aria-level="3" role="heading" id="h-note1"><span>Note</span></div><div class="">Implementations <em class="rfc2119" title="MAY">MAY</em> only implement a subset of the codecs and profiles mentioned in the RFC.</div></div>
         </dd>
       </dl>
     </section>
 
     <section id="mpeg2ts-general" typeof="bibo:Chapter" resource="#mpeg2ts-general" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mpeg2ts-general" resource="#h-mpeg2ts-general"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>General Transport Stream Requirements</span></h2>
-      <p>MPEG-2 TS media and initialization segments must conform to the MPEG-2 TS Adaptive Profile (ISO/IEC 13818-1:2012 Amd. 2).</p>
+      <p>MPEG-2 TS media and initialization segments <em class="rfc2119" title="MUST">MUST</em> conform to the MPEG-2 TS Adaptive Profile (ISO/IEC 13818-1:2012 Amd. 2).</p>
 
-      <p>The user agent must run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
       <ol>
         <li>Segments do not contain complete MPEG-2 TS packets.</li>
         <li>Segments do not contain complete PES packets and sections.</li>
@@ -375,21 +401,21 @@ table.simple {
     <section id="mpeg2ts-init-segments" typeof="bibo:Chapter" resource="#mpeg2ts-init-segments" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mpeg2ts-init-segments" resource="#h-mpeg2ts-init-segments"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Initialization Segments</span></h2>
       <p>An MPEG-2 TS initialization segment consists of a single PAT and a single PMT.</p>
-      <p>The user agent must run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
       <ol>
         <li>A PAT is not present in the <a href="index.html#init-segment">initialization segment</a></li>
         <li>A PMT is not present in the <a href="index.html#init-segment">initialization segment</a></li>
       </ol>
 
-      <p>The user agent must accept and ignore other SI, such as CAT, that are invariant for all subsequent media segments.</p>
-      <p>The user agent must source attribute values for id, kind, label and language for <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#audiotrack">AudioTrack</a></code>, <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#videotrack">VideoTrack</a></code> and
-        <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#texttrack">TextTrack</a></code> objects as described for MPEG-2 Transport Streams in the in-band tracks spec [<cite><a class="bibref" href="#bib-INBANDTRACKS">INBANDTRACKS</a></cite>].</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> accept and ignore other SI, such as CAT, that are invariant for all subsequent media segments.</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> source attribute values for id, kind, label and language for <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code>, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> and
+        <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> objects as described for MPEG-2 Transport Streams in the in-band tracks spec [<cite><a class="bibref" href="#bib-INBANDTRACKS">INBANDTRACKS</a></cite>].</p>
     </section>
 
     <section id="mpeg2ts-media-segments" typeof="bibo:Chapter" resource="#mpeg2ts-media-segments" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mpeg2ts-media-segments" resource="#h-mpeg2ts-media-segments"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Media Segments</span></h2>
 
-      <p>The user agent must run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are met:</p>
       <ol>
         <li>A media segment relies on initialization information in another media segment.</li>
         <li>At least one PES packet does not have a PTS timestamp.</li>
@@ -406,10 +432,10 @@ table.simple {
     </section>
     <section id="mpeg2ts-discontinuities" typeof="bibo:Chapter" resource="#mpeg2ts-discontinuities" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mpeg2ts-discontinuities" resource="#h-mpeg2ts-discontinuities"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Timestamp Rollover &amp; Discontinuities</span></h2>
-      <p>Timestamp rollovers and discontinuities must be handled by the UA. The UA's MPEG-2 TS implementation must maintain an internal offset
-        variable, <dfn id="mpeg2ts-timestampOffset" data-dfn-for="">MPEG2TS_timestampOffset</dfn>, to keep track of the offset that needs to be applied to timestamps
+      <p>Timestamp rollovers and discontinuities <em class="rfc2119" title="MUST">MUST</em> be handled by the UA. The UA's MPEG-2 TS implementation <em class="rfc2119" title="MUST">MUST</em> maintain an internal offset
+        variable, <dfn id="mpeg2ts-timestampOffset" data-dfn-for="" data-dfn-type="dfn">MPEG2TS_timestampOffset</dfn>, to keep track of the offset that needs to be applied to timestamps
         that have rolled over or are part of a discontinuity. <var>MPEG2TS_timestampOffset</var> is initially set to 0 when the <code><a href="index.html#idl-def-SourceBuffer" class="idlType">SourceBuffer</a></code> is
-        created.  This offset must be applied to the timestamps as part of the conversion process from MPEG-2 TS packets
+        created.  This offset <em class="rfc2119" title="MUST">MUST</em> be applied to the timestamps as part of the conversion process from MPEG-2 TS packets
         into <a href="index.html#coded-frame">coded frames</a> for the <a href="index.html#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>. This results in the coded frame timestamps
         for a packet being computed by the following equations:</p>
       <pre>        Coded Frame Presentation Timestamp = (MPEG-2 TS presentation timestamp) + <var>MPEG2TS_timestampOffset</var>
@@ -417,19 +443,31 @@ table.simple {
 
       <p><var><a href="#mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</a></var> is updated in the following ways:</p>
       <ul>
-        <li>Each time a timestamp rollover is detected, 2^33 must be added to <var><a href="#mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</a></var>.</li>
-        <li>When a discontinuity is detected, <var><a href="#mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</a></var> must be adjusted to make the timestamps after the discontinuity appear
+        <li>Each time a timestamp rollover is detected, 2^33 <em class="rfc2119" title="MUST">MUST</em> be added to <var><a href="#mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</a></var>.</li>
+        <li>When a discontinuity is detected, <var><a href="#mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</a></var> <em class="rfc2119" title="MUST">MUST</em> be adjusted to make the timestamps after the discontinuity appear
           to come immediately after the timestamps before the discontinuity.</li>
-        <li>When <code><a href="index.html#widl-SourceBuffer-abort-void">abort()</a></code> is called, <var><a href="#mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</a></var> must be set to 0.</li>
-        <li>When <code><a href="index.html#widl-SourceBuffer-timestampOffset">timestampOffset</a></code> is successfully set, <var><a href="#mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</a></var> must be set to 0.</li>
+        <li>When <code><a href="index.html#widl-SourceBuffer-abort-void">abort()</a></code> is called, <var><a href="#mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</a></var> <em class="rfc2119" title="MUST">MUST</em> be set to 0.</li>
+        <li>When <code><a href="index.html#widl-SourceBuffer-timestampOffset">timestampOffset</a></code> is successfully set, <var><a href="#mpeg2ts-timestampOffset">MPEG2TS_timestampOffset</a></var> <em class="rfc2119" title="MUST">MUST</em> be set to 0.</li>
       </ul>
     </section>
 
+    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart"><!--OddPage--><h2 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">8. </span>Conformance</span></h2>
+<p>
+  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
+  and notes in this specification are non-normative. Everything else in this specification is
+  normative.
+</p>
+<p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are 
+  to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+</p>
+</section>
+
     <section id="acknowledgements" typeof="bibo:Chapter" resource="#acknowledgements" property="bibo:hasPart">
-      <!--OddPage--><h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">8. </span>Acknowledgments</span></h2>
+      <!--OddPage--><h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">9. </span>Acknowledgments</span></h2>
       The editors would like to thank Alex Giladi, Bob Lund, David Singer, Duncan Rowden, Glenn Adams, Mark Vickers, and Michael Thornburgh for their contributions to this specification.
     </section>
   
 
-<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
+<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+</dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
 </dd></dl></section></section></body></html>

--- a/mpeg-audio-byte-stream-format-respec.html
+++ b/mpeg-audio-byte-stream-format-respec.html
@@ -45,8 +45,9 @@
       // editors, add as many as you like
       // only "name" is required
       editors:  [
-        { name: "Aaron Colwell",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
         { name: "Dale Curtis", url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
+        { name: "Matthew Wolenetz",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
+        { name: "Aaron Colwell (until April 2015)",  url: "", company: "Google Inc.", companyURL: "http://www.google.com/" },
       ],
 
       mseDefGroupName: "mpeg-byte-stream-format",
@@ -55,7 +56,7 @@
       ],
 
       // name of the WG
-      wg:           "HTML Working Group",
+      wg:           "HTML Media Extensions Working Group",
 
       // URI of the public WG page
       wgURI:        "http://www.w3.org/html/wg/",
@@ -113,7 +114,7 @@
         <li>"audio/aac" for sequences of ADTS frames, as specified in <a def-id="iso-14496-3"></a>.</li>
         <li>"audio/mpeg" for MPEG-1/2/2.5 Layer I/II/III streams, as specified in <a href="http://tools.ietf.org/html/rfc3003">RFC 3003</a>.</li>
       </ul>
-      <p>The "codecs" MIME-type parameter must not be used with these MIME-types.</p>
+      <p>The "codecs" MIME-type parameter MUST NOT be used with these MIME-types.</p>
     </section>
 
     <section id="mpeg-audio-frames">
@@ -127,7 +128,7 @@
 
     <section id="mpeg-metadata">
       <h4>Metadata Frames</h4>
-      <p>Since <a def-id="id3v1"></a>, <a def-id="id3v2"></a> metadata frames, and <a def-id="icecast-headers"></a> are common in existing MPEG audio streams, implementations should gracefully handle such frames. Zero or more of these metadata frames are allowed to occur before, after, or between <a def-id="mpeg-audio-frames"></a>. Minimal implementations must accept, consume, and ignore these frames. More advanced implementations may choose to expose the metadata information via an inband <a def-id="text-track"></a> or some other mechanism.</p>
+      <p>Since <a def-id="id3v1"></a>, <a def-id="id3v2"></a> metadata frames, and <a def-id="icecast-headers"></a> are common in existing MPEG audio streams, implementations SHOULD gracefully handle such frames. Zero or more of these metadata frames are allowed to occur before, after, or between <a def-id="mpeg-audio-frames"></a>. Minimal implementations MUST accept, consume, and ignore these frames. More advanced implementations MAY choose to expose the metadata information via an inband <a def-id="text-track"></a> or some other mechanism.</p>
 
       <section id="icecast">
         <h3>Icecast headers</h3>
@@ -149,6 +150,8 @@
         <li>The coded audio in each <a def-id="mpeg-audio-frame"></a> is a <a def-id="media-segment"></a>.</li>
       </ul>
     </section>
+
+    <section id="conformance"></section>
 
 <!--     <section id="acknowledgements">
       <h2>Acknowledgments</h2>

--- a/mpeg-audio-byte-stream-format.html
+++ b/mpeg-audio-byte-stream-format.html
@@ -15,40 +15,40 @@
     <meta name="bug.component" content="Media Source Extensions">
 
     <style>/* --- ISSUES/NOTES --- */
-div.issue-title, div.note-title , div.warning-title {
+div.issue-title, div.note-title , div.ednote-title, div.warning-title {
     padding-right:  1em;
     min-width: 7.5em;
     color: #b9ab2d;
 }
 div.issue-title { color: #e05252; }
-div.note-title { color: #2b2; }
+div.note-title, div.ednote-title { color: #2b2; }
 div.warning-title { color: #f22; }
-div.issue-title span, div.note-title span, div.warning-title span {
+div.issue-title span, div.note-title span, div.ednote-title span, div.warning-title span {
     text-transform: uppercase;
 }
-div.note, div.issue, div.warning {
+div.note, div.issue, div.ednote, div.warning {
     margin-top: 1em;
     margin-bottom: 1em;
 }
-.note > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
-.issue, .note, .warning {
+.note > p:first-child, .ednote > p:first-child, .issue > p:first-child, .warning > p:first-child { margin-top: 0 }
+.issue, .note, .ednote, .warning {
     padding: .5em;
     border-left-width: .5em;
     border-left-style: solid;
 }
-div.issue, div.note , div.warning {
+div.issue, div.note , div.ednote,  div.warning {
     padding: 1em 1.2em 0.5em;
     margin: 1em 0;
     position: relative;
     clear: both;
 }
-span.note, span.issue, span.warning { padding: .1em .5em .15em; }
+span.note, span.ednote, span.issue, span.warning { padding: .1em .5em .15em; }
 
 .issue {
     border-color: #e05252;
     background: #fbe9e9;
 }
-.note {
+.note, .ednote {
     border-color: #52e052;
     background: #e9fbe9;
 }
@@ -70,6 +70,15 @@ span.note, span.issue, span.warning { padding: .1em .5em .15em; }
     padding-right: .3em;
     vertical-align: top;
     margin-top: -0.5em;
+}
+
+li.task-list-item {
+    list-style: none;
+}
+
+input.task-list-item-checkbox {
+    margin: 0 0.35em 0.25em -1.6em;
+    vertical-align: middle;
 }
 </style><link rel="stylesheet" href="mse.css">
 
@@ -193,13 +202,15 @@ table.simple {
   <p>
       
         
-            <a href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/Icons/w3c_home" alt="W3C"></a>
+            <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/Icons/w3c_home" alt="W3C"></a>
+            
+            
         
       
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">MPEG Audio Byte Stream Format</h1>
   
-  <h2 id="w3c-editor-s-draft-09-march-2015"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2015-03-09">09 March 2015</time></h2>
+  <h2 id="w3c-editor-s-draft-20-july-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-07-20">20 July 2016</time></h2>
   <dl>
     
       <dt>This version:</dt>
@@ -220,10 +231,13 @@ table.simple {
     
     
     <dt>Editors:</dt>
-    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Dale Curtis</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
 <span property="rdf:rest" resource="_:editor1"></span>
 </dd>
-<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Dale Curtis</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Matthew Wolenetz</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+<span property="rdf:rest" resource="_:editor2"></span>
+</dd>
+<dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
 <span property="rdf:rest" resource="rdf:nil"></span>
 </dd>
 
@@ -237,7 +251,7 @@ table.simple {
     
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2015
+        2016
         
         <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
@@ -247,13 +261,15 @@ table.simple {
         <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
         
-          <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+          
+            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
+          
         
         rules apply.
       </p>
     
   
-  <hr>
+  <hr title="Separator for header">
 </div>
     <section id="abstract" class="introductory" property="dc:abstract"><h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2><p>
       This specification defines a <a href="http://www.w3.org/TR/media-source/">Media Source Extensions</a> byte stream format specification based on MPEG audio streams.
@@ -262,75 +278,82 @@ table.simple {
     
       
         <p>
-          <em>This section describes the status of this document at the time of its publication.
-          Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the
-          latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at
-          http://www.w3.org/TR/.</em>
+          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
         </p>
         
-        
-        
-        <p>
-          This document was published by the <a href="http://www.w3.org/html/wg/">HTML Working Group</a> as an Editor's Draft.
-          
-          
-            If you wish to make comments regarding this document, please send them to 
-            <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a> 
-            (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
-            <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
           
           
           
           
-          
-            
-            All comments are welcome.
-            
-          
-        </p>
-        
-        
-        
           <p>
-            Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
-            Membership. This is a draft document and may be updated, replaced or obsoleted by other
-            documents at any time. It is inappropriate to cite this document as other than work in
-            progress.
-          </p>
-        
-        
-        
-        <p>
-          
-            This document was produced by a group operating under the 
-            <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
-            Policy</a>.
-          
-          
-          
+            This document was published by the <a href="http://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft.
             
-              <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
-              disclosures</a> 
             
-            made in connection with the deliverables of the group; that page also includes
-            instructions for disclosing a patent. An individual who has actual knowledge of a patent
-            which the individual believes contains
-            <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-            Claim(s)</a> must disclose the information in accordance with
-            <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-            6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-          
-          
-        </p>
-        
-          <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2014/Process-20140801/">1 August 2014 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+              If you wish to make comments regarding this document, please send them to
+              <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>
+              (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
+              <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
+            
+            
+            
+            
+            
+              
+              All comments are welcome.
+              
+            
           </p>
-        
+          
+          
+          
+          
+            <p>
+              Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
+              Membership. This is a draft document and may be updated, replaced or obsoleted by other
+              documents at any time. It is inappropriate to cite this document as other than work in
+              progress.
+            </p>
+          
+          
+          
+          <p>
+            
+              This document was produced by
+              
+              a group
+               operating under the
+              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+              Policy</a>.
+            
+            
+            
+              
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
+                disclosures</a>
+              
+              made in connection with the deliverables of
+              
+              the group; that page also includes
+              
+              instructions for disclosing a patent. An individual who has actual knowledge of a patent
+              which the individual believes contains
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+              Claim(s)</a> must disclose the information in accordance with
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+            
+            
+          </p>
+          
+            <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+            </p>
+          
+          
         
       
     
   
-</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory" id="respecContents"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#mime-types" class="tocxref"><span class="secno">2. </span>MIME-types</a></li><li class="tocline"><a href="#mpeg-audio-frames" class="tocxref"><span class="secno">3. </span>MPEG Audio Frames</a></li><li class="tocline"><a href="#mpeg-metadata" class="tocxref"><span class="secno">4. </span>Metadata Frames</a><ul class="toc"><li class="tocline"><a href="#icecast" class="tocxref"><span class="secno">4.1 </span>Icecast headers</a></li></ul></li><li class="tocline"><a href="#mpeg-segments" class="tocxref"><span class="secno">5. </span>Segment Definitions</a></li></ul></section>
+</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#mime-types" class="tocxref"><span class="secno">2. </span>MIME-types</a></li><li class="tocline"><a href="#mpeg-audio-frames" class="tocxref"><span class="secno">3. </span>MPEG Audio Frames</a></li><li class="tocline"><a href="#mpeg-metadata" class="tocxref"><span class="secno">4. </span>Metadata Frames</a><ul class="toc"><li class="tocline"><a href="#icecast" class="tocxref"><span class="secno">4.1 </span>Icecast headers</a></li></ul></li><li class="tocline"><a href="#mpeg-segments" class="tocxref"><span class="secno">5. </span>Segment Definitions</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">6. </span>Conformance</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ul></li></ul></section>
 
     <section id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
@@ -345,12 +368,12 @@ table.simple {
         <li>"audio/aac" for sequences of ADTS frames, as specified in <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=53943">ISO/IEC 14496-3:2009</a>.</li>
         <li>"audio/mpeg" for MPEG-1/2/2.5 Layer I/II/III streams, as specified in <a href="http://tools.ietf.org/html/rfc3003">RFC 3003</a>.</li>
       </ul>
-      <p>The "codecs" MIME-type parameter must not be used with these MIME-types.</p>
+      <p>The "codecs" MIME-type parameter <em class="rfc2119" title="MUST NOT">MUST NOT</em> be used with these MIME-types.</p>
     </section>
 
     <section id="mpeg-audio-frames" typeof="bibo:Chapter" resource="#mpeg-audio-frames" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mpeg-audio-frames" resource="#h-mpeg-audio-frames"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>MPEG Audio Frames</span></h2>
-      <p>The format of an <dfn id="mpeg-audio-frame" data-dfn-for="">MPEG Audio Frame</dfn> depends on the <a href="#mime-types">MIME-type</a> used.</p>
+      <p>The format of an <dfn id="mpeg-audio-frame" data-dfn-for="" data-dfn-type="dfn">MPEG Audio Frame</dfn> depends on the <a href="#mime-types">MIME-type</a> used.</p>
       <ul>
         <li>If the "audio/aac" MIME-type is used, an MPEG Audio Frame is a sequence of bytes that conform to the adts_frame() syntax specified in Table 1.A.5 of <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=53943">ISO/IEC 14496-3:2009</a>.</li>
         <li>If the "audio/mpeg" MIME-type is used, an MPEG Audio Frame is a sequence of bytes that conform to the frame() syntax element specified in Section 2.4.1.2 of <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=22412">ISO/IEC 11172-3:1993</a> or the corresponding definition in <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=26797">ISO/IEC 13818-3:1998</a>.</li>
@@ -359,11 +382,11 @@ table.simple {
 
     <section id="mpeg-metadata" typeof="bibo:Chapter" resource="#mpeg-metadata" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mpeg-metadata" resource="#h-mpeg-metadata"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Metadata Frames</span></h2>
-      <p>Since <a href="http://id3.org/ID3v1">ID3v1</a>, <a href="http://id3.org/id3v2.3.0">ID3v2</a> metadata frames, and <a href="#icecast-header">Icecast headers</a> are common in existing MPEG audio streams, implementations should gracefully handle such frames. Zero or more of these metadata frames are allowed to occur before, after, or between <a href="#mpeg-audio-frame">MPEG Audio Frames</a>. Minimal implementations must accept, consume, and ignore these frames. More advanced implementations may choose to expose the metadata information via an inband <code><a href="http://www.w3.org/TR/html5/embedded-content-0.html#texttrack">TextTrack</a></code> or some other mechanism.</p>
+      <p>Since <a href="http://id3.org/ID3v1">ID3v1</a>, <a href="http://id3.org/id3v2.3.0">ID3v2</a> metadata frames, and <a href="#icecast-header">Icecast headers</a> are common in existing MPEG audio streams, implementations <em class="rfc2119" title="SHOULD">SHOULD</em> gracefully handle such frames. Zero or more of these metadata frames are allowed to occur before, after, or between <a href="#mpeg-audio-frame">MPEG Audio Frames</a>. Minimal implementations <em class="rfc2119" title="MUST">MUST</em> accept, consume, and ignore these frames. More advanced implementations <em class="rfc2119" title="MAY">MAY</em> choose to expose the metadata information via an inband <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> or some other mechanism.</p>
 
       <section id="icecast" typeof="bibo:Chapter" resource="#icecast" property="bibo:hasPart">
         <h3 id="h-icecast" resource="#h-icecast"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1 </span>Icecast headers</span></h3>
-        <p>There is no normative spec for <a href="http://en.wikipedia.org/wiki/Icecast">Icecast</a>/<a href="http://en.wikipedia.org/wiki/SHOUTcast">SHOUTcast</a> headers, just <a href="http://forums.radiotoolbox.com/viewtopic.php?t=74">examples</a>. For the purpose of this specification, an <dfn id="icecast-header" data-dfn-for="">Icecast header</dfn> is defined as beginning with the 4 character sequence "ICY&nbsp;"(U+0049 I, U+0043 C, U+0059 Y, U+0020 SPACE) and ending with a pair of carriage-return line-feed sequences (U+000D CARRIAGE RETURN, U+000A LINE FEED, U+000D CARRIAGE RETURN, U+000A LINE FEED).</p>
+        <p>There is no normative spec for <a href="http://en.wikipedia.org/wiki/Icecast">Icecast</a>/<a href="http://en.wikipedia.org/wiki/SHOUTcast">SHOUTcast</a> headers, just <a href="http://forums.radiotoolbox.com/viewtopic.php?t=74">examples</a>. For the purpose of this specification, an <dfn id="icecast-header" data-dfn-for="" data-dfn-type="dfn">Icecast header</dfn> is defined as beginning with the 4 character sequence "ICY&nbsp;"(U+0049 I, U+0043 C, U+0059 Y, U+0020 SPACE) and ending with a pair of carriage-return line-feed sequences (U+000D CARRIAGE RETURN, U+000A LINE FEED, U+000D CARRIAGE RETURN, U+000A LINE FEED).</p>
         <div class="note"><div class="note-title" aria-level="4" role="heading" id="h-note1"><span>Note</span></div><p class="">Icecast headers are allowed in the byte streams because some Icecast and SHOUTcast
           servers return a status line that looks like "ICY OK 200" instead of a standard HTTP status line.
           User-agent network stacks typically interpret this as an HTTP 0.9 response and include the
@@ -382,10 +405,22 @@ table.simple {
       </ul>
     </section>
 
+    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart"><!--OddPage--><h2 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Conformance</span></h2>
+<p>
+  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
+  and notes in this specification are non-normative. Everything else in this specification is
+  normative.
+</p>
+<p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, <em class="rfc2119" title="MUST NOT">MUST NOT</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are 
+  to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+</p>
+</section>
+
 <!--     <section id="acknowledgements">
       <h2>Acknowledgments</h2>
       The editors would like to thank <a def-id="contributors"></a> for their contributions to this specification.
     </section> -->
   
 
-<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form></body></html>
+<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+</dd></dl></section></section></body></html>

--- a/webm-byte-stream-format-respec.html
+++ b/webm-byte-stream-format-respec.html
@@ -161,7 +161,7 @@
             </tbody>
           </table>
           <div class="note">
-            Implementations should support all of the codec IDs mentioned in the table above.
+            Implementations SHOULD support all of the codec IDs mentioned in the table above.
           </div>
 
           <p>Examples of valid MIME-types with a codecs parameter.</p>
@@ -178,19 +178,19 @@
 
     <section id="webm-init-segments">
       <h2>Initialization Segments</h2>
-      <p>A WebM <a def-id="init-segment"></a> must contain a subset of the elements at the start of a typical WebM file.</p>
+      <p>A WebM <a def-id="init-segment"></a> MUST contain a subset of the elements at the start of a typical WebM file.</p>
 
-      <p>The user agent must run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are not met:</p>
+      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are not met:</p>
       <ol>
-	<li>The <a def-id="init-segment"></a> must start with an <a def-id="webm-ebml-header"></a> element, followed by a <a def-id="webm-segment"></a> header.</li>
-	<li>The size value in the <a def-id="webm-segment"></a> header must signal an "unknown size" or contain a value large enough to include the <a def-id="webm-info"></a> and <a def-id="webm-tracks"></a> elements that follow.</li>
-	<li>A <a def-id="webm-info"></a> element and a <a def-id="webm-tracks"></a> element must appear, in that order, after the <a def-id="webm-segment"></a> header and before any further <a def-id="webm-ebml-header"></a> or <a def-id="webm-cluster"></a> elements.
+	<li>The <a def-id="init-segment"></a> MUST start with an <a def-id="webm-ebml-header"></a> element, followed by a <a def-id="webm-segment"></a> header.</li>
+	<li>The size value in the <a def-id="webm-segment"></a> header MUST signal an "unknown size" or contain a value large enough to include the <a def-id="webm-info"></a> and <a def-id="webm-tracks"></a> elements that follow.</li>
+	<li>A <a def-id="webm-info"></a> element and a <a def-id="webm-tracks"></a> element MUST appear, in that order, after the <a def-id="webm-segment"></a> header and before any further <a def-id="webm-ebml-header"></a> or <a def-id="webm-cluster"></a> elements.
         </li>
       </ol>
-      <p>The user agent must accept and ignore any elements other than an <a def-id="webm-ebml-header"></a> or a <a def-id="webm-cluster"></a> that occur before, in between, or after the <a def-id="webm-info"></a> and
+      <p>The user agent MUST accept and ignore any elements other than an <a def-id="webm-ebml-header"></a> or a <a def-id="webm-cluster"></a> that occur before, in between, or after the <a def-id="webm-info"></a> and
       <a def-id="webm-tracks"></a> elements.</p>
 
-      <p>The user agent must source attribute values for id, kind, label and language for <a def-id="audio-track"></a>, <a def-id="video-track"></a> and
+      <p>The user agent MUST source attribute values for id, kind, label and language for <a def-id="audio-track"></a>, <a def-id="video-track"></a> and
         <a def-id="text-track"></a> objects as described for WebM in the in-band tracks spec [[INBANDTRACKS]].</p>
     </section>
 
@@ -202,25 +202,27 @@
       <ol>
         <li>The TimecodeScale in the <a def-id="webm-init-segment"></a> most recently appended applies to all timestamps in the <a def-id="webm-cluster"></a></li>
         <li>The Timecode element in the <a def-id="webm-cluster"></a> contains a <a def-id="presentation-timestamp"></a> in TimecodeScale units.</li>
-        <li>The Cluster header may contain an "unknown" size value. If it does then the end of the cluster is reached when another <a def-id="webm-cluster"></a> header or an element header that indicates the start
+        <li>The Cluster header MAY contain an "unknown" size value. If it does then the end of the cluster is reached when another <a def-id="webm-cluster"></a> header or an element header that indicates the start
           of an <a def-id="webm-init-segment"></a> is encountered.</li>
       </ol>
 
-      <p>The user agent must run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are not met:</p>
+      <p>The user agent MUST run the <a def-id="append-decode-error-algorithm"></a> if any of the following conditions are not met:</p>
       <ol>
-        <li>The Timecode element must appear before any Block &amp; SimpleBlock elements in a <a def-id="webm-cluster"></a>.</li>
+        <li>The Timecode element MUST appear before any Block &amp; SimpleBlock elements in a <a def-id="webm-cluster"></a>.</li>
         <li>Block &amp; SimpleBlock elements are in time increasing order consistent with the <a def-id="webm-spec"></a>.</li>
-        <li>If the most recent <a def-id="webm-init-segment"></a> describes multiple tracks, then blocks from all the tracks must be interleaved in time increasing order. At least one block from all audio and video
-          tracks must be present.</li>
+        <li>If the most recent <a def-id="webm-init-segment"></a> describes multiple tracks, then blocks from all the tracks MUST be interleaved in time increasing order. At least one block from all audio and video
+          tracks MUST be present.</li>
       </ol>
 
-      <p>The user agent must accept and ignore <a def-id="webm-cues"></a> or <a def-id="webm-chapters"></a> elements that follow a <a def-id="webm-cluster"></a> element.</p>
+      <p>The user agent MUST accept and ignore <a def-id="webm-cues"></a> or <a def-id="webm-chapters"></a> elements that follow a <a def-id="webm-cluster"></a> element.</p>
     </section>
 
     <section id="webm-random-access-points">
       <h2>Random Access Points</h2>
-      <p>Either a SimpleBlock element with its Keyframe flag set, or a BlockGroup element having no ReferenceBlock elements, signals the location of a <a def-id="random-access-point"></a> for that track. The order of multiplexed blocks within a <a def-id="media-segment"></a> must conform to the <a def-id="webm-muxer-guidelines"></a>.</p>
+      <p>Either a SimpleBlock element with its Keyframe flag set, or a BlockGroup element having no ReferenceBlock elements, signals the location of a <a def-id="random-access-point"></a> for that track. The order of multiplexed blocks within a <a def-id="media-segment"></a> MUST conform to the <a def-id="webm-muxer-guidelines"></a>.</p>
     </section>
+
+    <section id="conformance"></section>
 
     <section id="acknowledgements">
       <h2>Acknowledgments</h2>

--- a/webm-byte-stream-format.html
+++ b/webm-byte-stream-format.html
@@ -266,7 +266,7 @@ table.simple {
   </p>
   <h1 class="title p-name" id="title" property="dcterms:title">WebM Byte Stream Format</h1>
   
-  <h2 id="w3c-editor-s-draft-11-july-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-07-11">11 July 2016</time></h2>
+  <h2 id="w3c-editor-s-draft-20-july-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-07-20">20 July 2016</time></h2>
   <dl>
     
       <dt>This version:</dt>
@@ -409,7 +409,7 @@ table.simple {
       
     
   
-</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#webm-mime-parameters" class="tocxref"><span class="secno">2. </span>MIME-type parameters</a></li><li class="tocline"><a href="#webm-init-segments" class="tocxref"><span class="secno">3. </span>Initialization Segments</a></li><li class="tocline"><a href="#webm-media-segments" class="tocxref"><span class="secno">4. </span>Media Segments</a></li><li class="tocline"><a href="#webm-random-access-points" class="tocxref"><span class="secno">5. </span>Random Access Points</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">6. </span>Acknowledgments</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">A.1 </span>Informative references</a></li></ul></li></ul></section>
+</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#webm-mime-parameters" class="tocxref"><span class="secno">2. </span>MIME-type parameters</a></li><li class="tocline"><a href="#webm-init-segments" class="tocxref"><span class="secno">3. </span>Initialization Segments</a></li><li class="tocline"><a href="#webm-media-segments" class="tocxref"><span class="secno">4. </span>Media Segments</a></li><li class="tocline"><a href="#webm-random-access-points" class="tocxref"><span class="secno">5. </span>Random Access Points</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">6. </span>Conformance</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">7. </span>Acknowledgments</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">A.2 </span>Informative references</a></li></ul></li></ul></section>
 
     <section id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
@@ -457,7 +457,7 @@ table.simple {
             </tbody>
           </table>
           <div class="note"><div class="note-title" aria-level="3" role="heading" id="h-note1"><span>Note</span></div><div class="">
-            Implementations should support all of the codec IDs mentioned in the table above.
+            Implementations <em class="rfc2119" title="SHOULD">SHOULD</em> support all of the codec IDs mentioned in the table above.
           </div></div>
 
           <p>Examples of valid MIME-types with a codecs parameter.</p>
@@ -474,19 +474,19 @@ table.simple {
 
     <section id="webm-init-segments" typeof="bibo:Chapter" resource="#webm-init-segments" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-webm-init-segments" resource="#h-webm-init-segments"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Initialization Segments</span></h2>
-      <p>A WebM <a href="index.html#init-segment">initialization segment</a> must contain a subset of the elements at the start of a typical WebM file.</p>
+      <p>A WebM <a href="index.html#init-segment">initialization segment</a> <em class="rfc2119" title="MUST">MUST</em> contain a subset of the elements at the start of a typical WebM file.</p>
 
-      <p>The user agent must run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are not met:</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are not met:</p>
       <ol>
-	<li>The <a href="index.html#init-segment">initialization segment</a> must start with an <a href="http://www.webmproject.org/code/specs/container/#ebml-basics">EBML Header</a> element, followed by a <a href="http://www.webmproject.org/code/specs/container/#segment">Segment</a> header.</li>
-	<li>The size value in the <a href="http://www.webmproject.org/code/specs/container/#segment">Segment</a> header must signal an "unknown size" or contain a value large enough to include the <a href="http://www.webmproject.org/code/specs/container/#segment-information">Segment Information</a> and <a href="http://www.webmproject.org/code/specs/container/#track">Tracks</a> elements that follow.</li>
-	<li>A <a href="http://www.webmproject.org/code/specs/container/#segment-information">Segment Information</a> element and a <a href="http://www.webmproject.org/code/specs/container/#track">Tracks</a> element must appear, in that order, after the <a href="http://www.webmproject.org/code/specs/container/#segment">Segment</a> header and before any further <a href="http://www.webmproject.org/code/specs/container/#ebml-basics">EBML Header</a> or <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a> elements.
+	<li>The <a href="index.html#init-segment">initialization segment</a> <em class="rfc2119" title="MUST">MUST</em> start with an <a href="http://www.webmproject.org/code/specs/container/#ebml-basics">EBML Header</a> element, followed by a <a href="http://www.webmproject.org/code/specs/container/#segment">Segment</a> header.</li>
+	<li>The size value in the <a href="http://www.webmproject.org/code/specs/container/#segment">Segment</a> header <em class="rfc2119" title="MUST">MUST</em> signal an "unknown size" or contain a value large enough to include the <a href="http://www.webmproject.org/code/specs/container/#segment-information">Segment Information</a> and <a href="http://www.webmproject.org/code/specs/container/#track">Tracks</a> elements that follow.</li>
+	<li>A <a href="http://www.webmproject.org/code/specs/container/#segment-information">Segment Information</a> element and a <a href="http://www.webmproject.org/code/specs/container/#track">Tracks</a> element <em class="rfc2119" title="MUST">MUST</em> appear, in that order, after the <a href="http://www.webmproject.org/code/specs/container/#segment">Segment</a> header and before any further <a href="http://www.webmproject.org/code/specs/container/#ebml-basics">EBML Header</a> or <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a> elements.
         </li>
       </ol>
-      <p>The user agent must accept and ignore any elements other than an <a href="http://www.webmproject.org/code/specs/container/#ebml-basics">EBML Header</a> or a <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a> that occur before, in between, or after the <a href="http://www.webmproject.org/code/specs/container/#segment-information">Segment Information</a> and
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> accept and ignore any elements other than an <a href="http://www.webmproject.org/code/specs/container/#ebml-basics">EBML Header</a> or a <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a> that occur before, in between, or after the <a href="http://www.webmproject.org/code/specs/container/#segment-information">Segment Information</a> and
       <a href="http://www.webmproject.org/code/specs/container/#track">Tracks</a> elements.</p>
 
-      <p>The user agent must source attribute values for id, kind, label and language for <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code>, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> and
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> source attribute values for id, kind, label and language for <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#audiotrack-audiotrack">AudioTrack</a></code>, <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#videotrack-videotrack">VideoTrack</a></code> and
         <code><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#texttrack-texttrack">TextTrack</a></code> objects as described for WebM in the in-band tracks spec [<cite><a class="bibref" href="#bib-INBANDTRACKS">INBANDTRACKS</a></cite>].</p>
     </section>
 
@@ -498,31 +498,43 @@ table.simple {
       <ol>
         <li>The TimecodeScale in the <a href="#webm-init-segments">WebM initialization segment</a> most recently appended applies to all timestamps in the <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a></li>
         <li>The Timecode element in the <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a> contains a <a href="index.html#presentation-timestamp">presentation timestamp</a> in TimecodeScale units.</li>
-        <li>The Cluster header may contain an "unknown" size value. If it does then the end of the cluster is reached when another <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a> header or an element header that indicates the start
+        <li>The Cluster header <em class="rfc2119" title="MAY">MAY</em> contain an "unknown" size value. If it does then the end of the cluster is reached when another <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a> header or an element header that indicates the start
           of an <a href="#webm-init-segments">WebM initialization segment</a> is encountered.</li>
       </ol>
 
-      <p>The user agent must run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are not met:</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> run the <a href="index.html#sourcebuffer-append-error">append error algorithm</a> with the <var>decode error</var> parameter set to true if any of the following conditions are not met:</p>
       <ol>
-        <li>The Timecode element must appear before any Block &amp; SimpleBlock elements in a <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a>.</li>
+        <li>The Timecode element <em class="rfc2119" title="MUST">MUST</em> appear before any Block &amp; SimpleBlock elements in a <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a>.</li>
         <li>Block &amp; SimpleBlock elements are in time increasing order consistent with the <a href="http://www.webmproject.org/code/specs/container/#webm-guidelines">WebM spec</a>.</li>
-        <li>If the most recent <a href="#webm-init-segments">WebM initialization segment</a> describes multiple tracks, then blocks from all the tracks must be interleaved in time increasing order. At least one block from all audio and video
-          tracks must be present.</li>
+        <li>If the most recent <a href="#webm-init-segments">WebM initialization segment</a> describes multiple tracks, then blocks from all the tracks <em class="rfc2119" title="MUST">MUST</em> be interleaved in time increasing order. At least one block from all audio and video
+          tracks <em class="rfc2119" title="MUST">MUST</em> be present.</li>
       </ol>
 
-      <p>The user agent must accept and ignore <a href="http://www.webmproject.org/code/specs/container/#cueing-data">Cues</a> or <a href="http://www.webmproject.org/code/specs/container/#chapters">Chapters</a> elements that follow a <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a> element.</p>
+      <p>The user agent <em class="rfc2119" title="MUST">MUST</em> accept and ignore <a href="http://www.webmproject.org/code/specs/container/#cueing-data">Cues</a> or <a href="http://www.webmproject.org/code/specs/container/#chapters">Chapters</a> elements that follow a <a href="http://www.webmproject.org/code/specs/container/#cluster">Cluster</a> element.</p>
     </section>
 
     <section id="webm-random-access-points" typeof="bibo:Chapter" resource="#webm-random-access-points" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-webm-random-access-points" resource="#h-webm-random-access-points"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Random Access Points</span></h2>
-      <p>Either a SimpleBlock element with its Keyframe flag set, or a BlockGroup element having no ReferenceBlock elements, signals the location of a <a href="index.html#random-access-point">random access point</a> for that track. The order of multiplexed blocks within a <a href="index.html#media-segment">media segment</a> must conform to the <a href="http://www.webmproject.org/code/specs/container/#muxer-guidelines">WebM Muxer Guidelines</a>.</p>
+      <p>Either a SimpleBlock element with its Keyframe flag set, or a BlockGroup element having no ReferenceBlock elements, signals the location of a <a href="index.html#random-access-point">random access point</a> for that track. The order of multiplexed blocks within a <a href="index.html#media-segment">media segment</a> <em class="rfc2119" title="MUST">MUST</em> conform to the <a href="http://www.webmproject.org/code/specs/container/#muxer-guidelines">WebM Muxer Guidelines</a>.</p>
     </section>
 
+    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart"><!--OddPage--><h2 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Conformance</span></h2>
+<p>
+  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
+  and notes in this specification are non-normative. Everything else in this specification is
+  normative.
+</p>
+<p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are 
+  to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+</p>
+</section>
+
     <section id="acknowledgements" typeof="bibo:Chapter" resource="#acknowledgements" property="bibo:hasPart">
-      <!--OddPage--><h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">6. </span>Acknowledgments</span></h2>
+      <!--OddPage--><h2 id="h-acknowledgements" resource="#h-acknowledgements"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Acknowledgments</span></h2>
       The editors would like to thank Frank Galligan, and Philip Jägenstedt for their contributions to this specification.
     </section>
   
 
-<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
+<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+</dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
 </dd></dl></section></section></body></html>


### PR DESCRIPTION
The main MSE spec will later need a biblio update to reflect
the editor updates included in the byte stream format registry in this
change. The registry also includes a WG name update.

The isobmff, mp2t, and mpeg audio byte stream format specs include
editor and WG name updates (the webm format spec already had those
updates.)