### PR TITLE
Fix #49: Update byte stream format registry and spec headers, sotd, bug links, etc.

### DIFF
--- a/byte-stream-format-registry-respec.html
+++ b/byte-stream-format-registry-respec.html
@@ -11,7 +11,7 @@
       specStatus: "ED",
 
       // the specification's short name, as in http://www.w3.org/TR/short-name/
-      shortName: "",
+      shortName: "media-source", <!-- The registry does not have its own short name. -->
 
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/media-source/byte-stream-format-registry.html",
@@ -58,21 +58,42 @@
 
       scheme: "https",
 
+      otherLinks: [{
+      key: 'Repository',
+      data: [{
+          value: 'We are on GitHub',
+          href: 'https://github.com/w3c/media-source/'
+        }, {
+          value: 'File a bug',
+          href: 'https://github.com/w3c/media-source/issues'
+        }, {
+          value: 'Commit history',
+          href: 'https://github.com/w3c/media-source/commits/gh-pages/byte-stream-format-registry-respec.html'
+        }]
+      },{
+        key: 'Mailing list',
+        data: [{
+          value: 'public-html-media@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+        }]
+      }],
+
       preProcess: [ mediaSourcePreProcessor ],
 
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
-      definitionMap: {
-      },
+      definitionMap: {},
 
       postProcess: [ mediaSourcePostProcessor ]
       };
     </script>
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <link rel="stylesheet" href="mse.css">
 
@@ -85,6 +106,15 @@
     </style>
   </head>
   <body>
+
+    <section id="abstract">
+      <p>This specification defines the byte stream formats for use with the <a def-id="mse-spec"></a> specification.</p>
+    </section>
+
+    <section id="sotd">
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+    </section>
 
     <section id="purpose">
       <h2>Purpose</h2>

--- a/byte-stream-format-registry.html
+++ b/byte-stream-format-registry.html
@@ -7,10 +7,12 @@
     
     
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <link rel="stylesheet" href="mse.css">
 
@@ -138,7 +140,7 @@ table.simple {
 }
 </style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
   "specStatus": "ED",
-  "shortName": "",
+  "shortName": "media-source",
   "edDraftURI": "https://w3c.github.io/media-source/byte-stream-format-registry.html",
   "prevVersion": "http://www.w3.org/2013/12/byte-stream-format-registry/",
   "editors": [
@@ -172,6 +174,34 @@ table.simple {
   "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/40318/status",
   "noIDLIn": true,
   "scheme": "https",
+  "otherLinks": [
+    {
+      "key": "Repository",
+      "data": [
+        {
+          "value": "We are on GitHub",
+          "href": "https://github.com/w3c/media-source/"
+        },
+        {
+          "value": "File a bug",
+          "href": "https://github.com/w3c/media-source/issues"
+        },
+        {
+          "value": "Commit history",
+          "href": "https://github.com/w3c/media-source/commits/gh-pages/byte-stream-format-registry-respec.html"
+        }
+      ]
+    },
+    {
+      "key": "Mailing list",
+      "data": [
+        {
+          "value": "public-html-media@w3.org",
+          "href": "https://lists.w3.org/Archives/Public/public-html-media/"
+        }
+      ]
+    }
+  ],
   "preProcess": [
     null
   ],
@@ -198,7 +228,7 @@ table.simple {
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/media-source/byte-stream-format-registry.html">https://w3c.github.io/media-source/byte-stream-format-registry.html</a></dd>
       <dt>Latest published version:</dt>
-      <dd><a href="http://www.w3.org/TR//">http://www.w3.org/TR//</a></dd>
+      <dd><a href="http://www.w3.org/TR/media-source/">http://www.w3.org/TR/media-source/</a></dd>
     
     
       <dt>Latest editor's draft:</dt>
@@ -224,6 +254,54 @@ table.simple {
 </dd>
 
     
+    
+      
+        
+          <dt>Repository:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/">
+                      We are on GitHub
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/issues">
+                      File a bug
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/commits/gh-pages/byte-stream-format-registry-respec.html">
+                      Commit history
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
+        
+          <dt>Mailing list:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://lists.w3.org/Archives/Public/public-html-media/">
+                      public-html-media@w3.org
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
     
   </dl>
   
@@ -253,6 +331,95 @@ table.simple {
   
   <hr title="Separator for header">
 </div>
+
+    <section id="abstract" class="introductory" property="dc:abstract"><h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+      <p>This specification defines the byte stream formats for use with the <a href="index.html#">Media Source Extensions</a> specification.</p>
+    </section><section id="sotd" class="introductory"><h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+  
+    
+      
+        <p>
+          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
+        </p>
+        
+          
+          
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+    
+          
+          
+          <p>
+            This document was published by the <a href="http://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft.
+            
+            
+              If you wish to make comments regarding this document, please send them to
+              <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>
+              (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
+              <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
+            
+            
+            
+            
+            
+              
+              All comments are welcome.
+              
+            
+          </p>
+          
+          
+          
+          
+            <p>
+              Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
+              Membership. This is a draft document and may be updated, replaced or obsoleted by other
+              documents at any time. It is inappropriate to cite this document as other than work in
+              progress.
+            </p>
+          
+          
+          
+          <p>
+            
+              This document was produced by
+              
+              a group
+               operating under the
+              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+              Policy</a>.
+            
+            
+            
+              
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
+                disclosures</a>
+              
+              made in connection with the deliverables of
+              
+              the group; that page also includes
+              
+              instructions for disclosing a patent. An individual who has actual knowledge of a patent
+              which the individual believes contains
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+              Claim(s)</a> must disclose the information in accordance with
+              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+              6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+            
+            
+          </p>
+          
+            <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+            </p>
+          
+          
+        
+      
+    
+  
+</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#purpose" class="tocxref"><span class="secno">1. </span>Purpose</a></li><li class="tocline"><a href="#organization" class="tocxref"><span class="secno">2. </span>Organization</a></li><li class="tocline"><a href="#entry-requirements" class="tocxref"><span class="secno">3. </span>Registration Entry Requirements</a></li><li class="tocline"><a href="#registry" class="tocxref"><span class="secno">4. </span>Registry</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">5. </span>Conformance</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ul></li></ul></section>
+
+    
 
     <section id="purpose" typeof="bibo:Chapter" resource="#purpose" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-purpose" resource="#h-purpose"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Purpose</span></h2>
@@ -348,5 +515,5 @@ table.simple {
 </section>
   
 
-<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+<section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
 </dd></dl></section></section></body></html>

--- a/isobmff-byte-stream-format-respec.html
+++ b/isobmff-byte-stream-format-respec.html
@@ -22,7 +22,7 @@
       specStatus: "ED",
 
       // the specification's short name, as in http://www.w3.org/TR/short-name/
-      shortName: "",
+      shortName: "media-source", <!-- The registry does not have its own short name -->
 
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/media-source/isobmff-byte-stream-format.html",
@@ -78,6 +78,26 @@
 
       scheme: "https",
 
+      otherLinks: [{
+      key: 'Repository',
+      data: [{
+          value: 'We are on GitHub',
+          href: 'https://github.com/w3c/media-source/'
+        }, {
+          value: 'File a bug',
+          href: 'https://github.com/w3c/media-source/issues'
+        }, {
+          value: 'Commit history',
+          href: 'https://github.com/w3c/media-source/commits/gh-pages/isobmff-byte-stream-format-respec.html'
+        }]
+      },{
+        key: 'Mailing list',
+        data: [{
+          value: 'public-html-media@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+        }]
+      }],
+
       preProcess: [ mediaSourcePreProcessor ],
 
       // Empty definitions for objects declared in the document are here to
@@ -98,10 +118,12 @@
       };
     </script>
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <link rel="stylesheet" href="mse.css">
     <style>
@@ -114,6 +136,11 @@
     <section id="abstract">
       This specification defines a <a href="http://www.w3.org/TR/media-source/">Media Source Extensions</a> byte stream format specification based on the ISO Base Media
       File Format.
+    </section>
+
+    <section id="sotd">
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
     </section>
 
     <section id="introduction">
@@ -233,6 +260,7 @@
               <ul>
                 <li>Issue 115 - Updated editors and updated to use RFC2119 key word mark-up and reference.</li>
                 <li>Issue 50 - Moved avc1-4 to non-normative note.</li>
+                <li>Issue 49 - Added headers, SOTD. Removed file-a-bugzilla link.</li>
               </ul>
             </td>
           </tr>

--- a/isobmff-byte-stream-format.html
+++ b/isobmff-byte-stream-format.html
@@ -9,10 +9,12 @@
 
     
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <style>/* --- ISSUES/NOTES --- */
 div.issue-title, div.note-title , div.ednote-title, div.warning-title {
@@ -203,7 +205,7 @@ table.simple {
 }
 </style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
   "specStatus": "ED",
-  "shortName": "",
+  "shortName": "media-source",
   "edDraftURI": "https://w3c.github.io/media-source/isobmff-byte-stream-format.html",
   "prevVersion": "http://www.w3.org/2013/12/byte-stream-format-registry/isobmff-byte-stream-format.html",
   "editors": [
@@ -260,6 +262,34 @@ table.simple {
   "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/40318/status",
   "noIDLIn": true,
   "scheme": "https",
+  "otherLinks": [
+    {
+      "key": "Repository",
+      "data": [
+        {
+          "value": "We are on GitHub",
+          "href": "https://github.com/w3c/media-source/"
+        },
+        {
+          "value": "File a bug",
+          "href": "https://github.com/w3c/media-source/issues"
+        },
+        {
+          "value": "Commit history",
+          "href": "https://github.com/w3c/media-source/commits/gh-pages/isobmff-byte-stream-format-respec.html"
+        }
+      ]
+    },
+    {
+      "key": "Mailing list",
+      "data": [
+        {
+          "value": "public-html-media@w3.org",
+          "href": "https://lists.w3.org/Archives/Public/public-html-media/"
+        }
+      ]
+    }
+  ],
   "preProcess": [
     null
   ],
@@ -301,7 +331,7 @@ table.simple {
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/media-source/isobmff-byte-stream-format.html">https://w3c.github.io/media-source/isobmff-byte-stream-format.html</a></dd>
       <dt>Latest published version:</dt>
-      <dd><a href="http://www.w3.org/TR//">http://www.w3.org/TR//</a></dd>
+      <dd><a href="http://www.w3.org/TR/media-source/">http://www.w3.org/TR/media-source/</a></dd>
     
     
       <dt>Latest editor's draft:</dt>
@@ -333,6 +363,54 @@ table.simple {
 </dd>
 
     
+    
+      
+        
+          <dt>Repository:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/">
+                      We are on GitHub
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/issues">
+                      File a bug
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/commits/gh-pages/isobmff-byte-stream-format-respec.html">
+                      Commit history
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
+        
+          <dt>Mailing list:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://lists.w3.org/Archives/Public/public-html-media/">
+                      public-html-media@w3.org
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
     
   </dl>
   
@@ -375,6 +453,9 @@ table.simple {
         
           
           
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+    
           
           
           <p>
@@ -446,6 +527,8 @@ table.simple {
     
   
 </section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#mime-parameters" class="tocxref"><span class="secno">2. </span>MIME-type parameters</a></li><li class="tocline"><a href="#iso-init-segments" class="tocxref"><span class="secno">3. </span>Initialization Segments</a></li><li class="tocline"><a href="#iso-media-segments" class="tocxref"><span class="secno">4. </span>Media Segments</a></li><li class="tocline"><a href="#iso-random-access-points" class="tocxref"><span class="secno">5. </span>Random Access Points</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">6. </span>Conformance</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">7. </span>Acknowledgments</a></li><li class="tocline"><a href="#revision-history" class="tocxref"><span class="secno">8. </span>Revision History</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">A.2 </span>Informative references</a></li></ul></li></ul></section>
+
+    
 
     <section id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
@@ -573,6 +656,7 @@ table.simple {
               <ul>
                 <li>Issue 115 - Updated editors and updated to use RFC2119 key word mark-up and reference.</li>
                 <li>Issue 50 - Moved avc1-4 to non-normative note.</li>
+                <li>Issue 49 - Added headers, SOTD. Removed file-a-bugzilla link.</li>
               </ul>
             </td>
           </tr>
@@ -617,6 +701,6 @@ table.simple {
       </table>
   
 
-</section><form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+</section><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
 </dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
 </dd></dl></section></section></body></html>

--- a/mp2t-byte-stream-format-respec.html
+++ b/mp2t-byte-stream-format-respec.html
@@ -23,7 +23,7 @@
       specStatus: "ED",
 
       // the specification's short name, as in http://www.w3.org/TR/short-name/
-      shortName: "",
+      shortName: "media-source", <!-- The registry does not have its own short name. -->
 
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/media-source/mp2t-byte-stream-format.html",
@@ -76,13 +76,31 @@
 
       scheme: "https",
 
+      otherLinks: [{
+      key: 'Repository',
+      data: [{
+          value: 'We are on GitHub',
+          href: 'https://github.com/w3c/media-source/'
+        }, {
+          value: 'File a bug',
+          href: 'https://github.com/w3c/media-source/issues'
+        }, {
+          value: 'Commit history',
+          href: 'https://github.com/w3c/media-source/commits/gh-pages/mp2t-byte-stream-format-respec.html'
+        }]
+      },{
+        key: 'Mailing list',
+        data: [{
+          value: 'public-html-media@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+        }]
+      }],
+
       preProcess: [ mediaSourcePreProcessor ],
 
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
-      definitionMap: {
-        SourceBuffer: function() {},
-      },
+      definitionMap: {},
 
       postProcess: [ mediaSourcePostProcessor ],
 
@@ -98,10 +116,12 @@
       };
     </script>
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <link rel="stylesheet" href="mse.css">
 
@@ -109,6 +129,11 @@
   <body>
     <section id="abstract">
       This specification defines a <a href="http://www.w3.org/TR/media-source/">Media Source Extensions</a> byte stream format specification based on MPEG-2 Transport Streams.
+    </section>
+
+    <section id="sotd">
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
     </section>
 
     <section id="introduction">

--- a/mp2t-byte-stream-format.html
+++ b/mp2t-byte-stream-format.html
@@ -9,10 +9,12 @@
 
     
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <style>/* --- ISSUES/NOTES --- */
 div.issue-title, div.note-title , div.ednote-title, div.warning-title {
@@ -197,7 +199,113 @@ table.simple {
         display: none;
     }
 }
-</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--></head>
+</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
+  "specStatus": "ED",
+  "shortName": "media-source",
+  "edDraftURI": "https://w3c.github.io/media-source/mp2t-byte-stream-format.html",
+  "prevVersion": "http://www.w3.org/2013/12/byte-stream-format-registry/mp2t-byte-stream-format.html",
+  "editors": [
+    {
+      "name": "Matthew Wolenetz",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    },
+    {
+      "name": "Jerry Smith",
+      "url": "",
+      "company": "Microsoft Corporation",
+      "companyURL": "http://www.microsoft.com/"
+    },
+    {
+      "name": "Mark Watson",
+      "url": "",
+      "company": "Netflix Inc.",
+      "companyURL": "http://www.netflix.com/"
+    },
+    {
+      "name": "Aaron Colwell (until April 2015)",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    },
+    {
+      "name": "Adrian Bateman (until April 2015)",
+      "url": "",
+      "company": "Microsoft Corporation",
+      "companyURL": "http://www.microsoft.com/"
+    }
+  ],
+  "mseDefGroupName": "mp2t-byte-stream-format",
+  "mseUnusedGroupNameExcludeList": [
+    "media-source"
+  ],
+  "mseContributors": [
+    "Alex Giladi",
+    "Bob Lund",
+    "David Singer",
+    "Duncan Rowden",
+    "Glenn Adams",
+    "Mark Vickers",
+    "Michael Thornburgh"
+  ],
+  "wg": "HTML Media Extensions Working Group",
+  "wgURI": "http://www.w3.org/html/wg/",
+  "wgPublicList": "public-html-media",
+  "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/40318/status",
+  "noIDLIn": true,
+  "scheme": "https",
+  "otherLinks": [
+    {
+      "key": "Repository",
+      "data": [
+        {
+          "value": "We are on GitHub",
+          "href": "https://github.com/w3c/media-source/"
+        },
+        {
+          "value": "File a bug",
+          "href": "https://github.com/w3c/media-source/issues"
+        },
+        {
+          "value": "Commit history",
+          "href": "https://github.com/w3c/media-source/commits/gh-pages/mp2t-byte-stream-format-respec.html"
+        }
+      ]
+    },
+    {
+      "key": "Mailing list",
+      "data": [
+        {
+          "value": "public-html-media@w3.org",
+          "href": "https://lists.w3.org/Archives/Public/public-html-media/"
+        }
+      ]
+    }
+  ],
+  "preProcess": [
+    null
+  ],
+  "definitionMap": {
+    "mpeg2ts_timestampoffset": [
+      "mpeg2ts-timestampOffset"
+    ]
+  },
+  "postProcess": [
+    null
+  ],
+  "localBiblio": {
+    "INBANDTRACKS": {
+      "title": "Sourcing In-band Media Resource Tracks from Media Containers into HTML",
+      "href": "http://dev.w3.org/html5/html-sourcing-inband-tracks/",
+      "authors": [
+        "Bob Lund",
+        "Silvia Pfeiffer"
+      ],
+      "publisher": "W3C"
+    }
+  }
+}</script></head>
   <body class="h-entry" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
   <p>
       
@@ -216,7 +324,7 @@ table.simple {
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/media-source/mp2t-byte-stream-format.html">https://w3c.github.io/media-source/mp2t-byte-stream-format.html</a></dd>
       <dt>Latest published version:</dt>
-      <dd><a href="http://www.w3.org/TR//">http://www.w3.org/TR//</a></dd>
+      <dd><a href="http://www.w3.org/TR/media-source/">http://www.w3.org/TR/media-source/</a></dd>
     
     
       <dt>Latest editor's draft:</dt>
@@ -248,6 +356,54 @@ table.simple {
 </dd>
 
     
+    
+      
+        
+          <dt>Repository:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/">
+                      We are on GitHub
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/issues">
+                      File a bug
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/commits/gh-pages/mp2t-byte-stream-format-respec.html">
+                      Commit history
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
+        
+          <dt>Mailing list:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://lists.w3.org/Archives/Public/public-html-media/">
+                      public-html-media@w3.org
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
     
   </dl>
   
@@ -289,6 +445,9 @@ table.simple {
         
           
           
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+    
           
           
           <p>
@@ -360,6 +519,8 @@ table.simple {
     
   
 </section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#mime-parameters" class="tocxref"><span class="secno">2. </span>MIME-type info</a></li><li class="tocline"><a href="#mpeg2ts-general" class="tocxref"><span class="secno">3. </span>General Transport Stream Requirements</a></li><li class="tocline"><a href="#mpeg2ts-init-segments" class="tocxref"><span class="secno">4. </span>Initialization Segments</a></li><li class="tocline"><a href="#mpeg2ts-media-segments" class="tocxref"><span class="secno">5. </span>Media Segments</a></li><li class="tocline"><a href="#mpeg2ts-random-access-points" class="tocxref"><span class="secno">6. </span>Random Access Points</a></li><li class="tocline"><a href="#mpeg2ts-discontinuities" class="tocxref"><span class="secno">7. </span>Timestamp Rollover &amp; Discontinuities</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">8. </span>Conformance</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">9. </span>Acknowledgments</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">A.2 </span>Informative references</a></li></ul></li></ul></section>
+
+    
 
     <section id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
@@ -433,7 +594,7 @@ table.simple {
     <section id="mpeg2ts-discontinuities" typeof="bibo:Chapter" resource="#mpeg2ts-discontinuities" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mpeg2ts-discontinuities" resource="#h-mpeg2ts-discontinuities"><span property="xhv:role" resource="xhv:heading"><span class="secno">7. </span>Timestamp Rollover &amp; Discontinuities</span></h2>
       <p>Timestamp rollovers and discontinuities <em class="rfc2119" title="MUST">MUST</em> be handled by the UA. The UA's MPEG-2 TS implementation <em class="rfc2119" title="MUST">MUST</em> maintain an internal offset
-        variable, <dfn id="mpeg2ts-timestampOffset" data-dfn-for="" data-dfn-type="dfn">MPEG2TS_timestampOffset</dfn>, to keep track of the offset that needs to be applied to timestamps
+        variable, <dfn id="mpeg2ts-timestampOffset" data-dfn-type="dfn">MPEG2TS_timestampOffset</dfn>, to keep track of the offset that needs to be applied to timestamps
         that have rolled over or are part of a discontinuity. <var>MPEG2TS_timestampOffset</var> is initially set to 0 when the <code><a href="index.html#idl-def-SourceBuffer" class="idlType">SourceBuffer</a></code> is
         created.  This offset <em class="rfc2119" title="MUST">MUST</em> be applied to the timestamps as part of the conversion process from MPEG-2 TS packets
         into <a href="index.html#coded-frame">coded frames</a> for the <a href="index.html#sourcebuffer-coded-frame-processing">coded frame processing algorithm</a>. This results in the coded frame timestamps
@@ -468,6 +629,6 @@ table.simple {
     </section>
   
 
-<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+<section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
 </dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
 </dd></dl></section></section></body></html>

--- a/mpeg-audio-byte-stream-format-respec.html
+++ b/mpeg-audio-byte-stream-format-respec.html
@@ -31,7 +31,7 @@
       specStatus: "ED",
 
       // the specification's short name, as in http://www.w3.org/TR/short-name/
-      shortName: "",
+      shortName: "media-source", <!-- The registry does not have its own short name. -->
 
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/media-source/mpeg-audio-byte-stream-format.html",
@@ -75,23 +75,43 @@
 
       scheme: "https",
 
+      otherLinks: [{
+      key: 'Repository',
+      data: [{
+          value: 'We are on GitHub',
+          href: 'https://github.com/w3c/media-source/'
+        }, {
+          value: 'File a bug',
+          href: 'https://github.com/w3c/media-source/issues'
+        }, {
+          value: 'Commit history',
+          href: 'https://github.com/w3c/media-source/commits/gh-pages/mpeg-audio-byte-stream-format-respec.html'
+        }]
+      },{
+        key: 'Mailing list',
+        data: [{
+          value: 'public-html-media@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+        }]
+      }],
+
       preProcess: [ mediaSourcePreProcessor ],
 
       // Empty definitions for objects declared in the document are here to
       // prevent error messages from being displayed for references to these objects.
-      definitionMap: {
-        SourceBuffer: function() {},
-      },
+      definitionMap: {},
 
       postProcess: [ mediaSourcePostProcessor ]
 
       };
     </script>
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <link rel="stylesheet" href="mse.css">
 
@@ -99,6 +119,11 @@
   <body>
     <section id="abstract">
       This specification defines a <a href="http://www.w3.org/TR/media-source/">Media Source Extensions</a> byte stream format specification based on MPEG audio streams.
+    </section>
+
+    <section id="sotd">
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
     </section>
 
     <section id="introduction">

--- a/mpeg-audio-byte-stream-format.html
+++ b/mpeg-audio-byte-stream-format.html
@@ -9,10 +9,12 @@
 
     
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <style>/* --- ISSUES/NOTES --- */
 div.issue-title, div.note-title , div.ednote-title, div.warning-title {
@@ -197,7 +199,85 @@ table.simple {
         display: none;
     }
 }
-</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--></head>
+</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
+  "specStatus": "ED",
+  "shortName": "media-source",
+  "edDraftURI": "https://w3c.github.io/media-source/mpeg-audio-byte-stream-format.html",
+  "prevVersion": "http://www.w3.org/2013/12/byte-stream-format-registry/mpeg-audio-byte-stream-format.html",
+  "editors": [
+    {
+      "name": "Dale Curtis",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    },
+    {
+      "name": "Matthew Wolenetz",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    },
+    {
+      "name": "Aaron Colwell (until April 2015)",
+      "url": "",
+      "company": "Google Inc.",
+      "companyURL": "http://www.google.com/"
+    }
+  ],
+  "mseDefGroupName": "mpeg-byte-stream-format",
+  "mseUnusedGroupNameExcludeList": [
+    "media-source"
+  ],
+  "mseContributors": [],
+  "wg": "HTML Media Extensions Working Group",
+  "wgURI": "http://www.w3.org/html/wg/",
+  "wgPublicList": "public-html-media",
+  "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/40318/status",
+  "noIDLIn": true,
+  "scheme": "https",
+  "otherLinks": [
+    {
+      "key": "Repository",
+      "data": [
+        {
+          "value": "We are on GitHub",
+          "href": "https://github.com/w3c/media-source/"
+        },
+        {
+          "value": "File a bug",
+          "href": "https://github.com/w3c/media-source/issues"
+        },
+        {
+          "value": "Commit history",
+          "href": "https://github.com/w3c/media-source/commits/gh-pages/mpeg-audio-byte-stream-format-respec.html"
+        }
+      ]
+    },
+    {
+      "key": "Mailing list",
+      "data": [
+        {
+          "value": "public-html-media@w3.org",
+          "href": "https://lists.w3.org/Archives/Public/public-html-media/"
+        }
+      ]
+    }
+  ],
+  "preProcess": [
+    null
+  ],
+  "definitionMap": {
+    "mpeg audio frame": [
+      "mpeg-audio-frame"
+    ],
+    "icecast header": [
+      "icecast-header"
+    ]
+  },
+  "postProcess": [
+    null
+  ]
+}</script></head>
   <body class="h-entry" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
   <p>
       
@@ -216,7 +296,7 @@ table.simple {
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/media-source/mpeg-audio-byte-stream-format.html">https://w3c.github.io/media-source/mpeg-audio-byte-stream-format.html</a></dd>
       <dt>Latest published version:</dt>
-      <dd><a href="http://www.w3.org/TR//">http://www.w3.org/TR//</a></dd>
+      <dd><a href="http://www.w3.org/TR/media-source/">http://www.w3.org/TR/media-source/</a></dd>
     
     
       <dt>Latest editor's draft:</dt>
@@ -242,6 +322,54 @@ table.simple {
 </dd>
 
     
+    
+      
+        
+          <dt>Repository:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/">
+                      We are on GitHub
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/issues">
+                      File a bug
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/commits/gh-pages/mpeg-audio-byte-stream-format-respec.html">
+                      Commit history
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
+        
+          <dt>Mailing list:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://lists.w3.org/Archives/Public/public-html-media/">
+                      public-html-media@w3.org
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
     
   </dl>
   
@@ -283,6 +411,9 @@ table.simple {
         
           
           
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+    
           
           
           <p>
@@ -355,6 +486,8 @@ table.simple {
   
 </section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#mime-types" class="tocxref"><span class="secno">2. </span>MIME-types</a></li><li class="tocline"><a href="#mpeg-audio-frames" class="tocxref"><span class="secno">3. </span>MPEG Audio Frames</a></li><li class="tocline"><a href="#mpeg-metadata" class="tocxref"><span class="secno">4. </span>Metadata Frames</a><ul class="toc"><li class="tocline"><a href="#icecast" class="tocxref"><span class="secno">4.1 </span>Icecast headers</a></li></ul></li><li class="tocline"><a href="#mpeg-segments" class="tocxref"><span class="secno">5. </span>Segment Definitions</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">6. </span>Conformance</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ul></li></ul></section>
 
+    
+
     <section id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
       <p>This specification defines segment formats for implementations that choose to support MPEG audio streams specified in <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=22412">ISO/IEC 11172-3:1993</a>, <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=26797">ISO/IEC 13818-3:1998</a>, and <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=53943">ISO/IEC 14496-3:2009</a>.</p>
@@ -373,7 +506,7 @@ table.simple {
 
     <section id="mpeg-audio-frames" typeof="bibo:Chapter" resource="#mpeg-audio-frames" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-mpeg-audio-frames" resource="#h-mpeg-audio-frames"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>MPEG Audio Frames</span></h2>
-      <p>The format of an <dfn id="mpeg-audio-frame" data-dfn-for="" data-dfn-type="dfn">MPEG Audio Frame</dfn> depends on the <a href="#mime-types">MIME-type</a> used.</p>
+      <p>The format of an <dfn id="mpeg-audio-frame" data-dfn-type="dfn">MPEG Audio Frame</dfn> depends on the <a href="#mime-types">MIME-type</a> used.</p>
       <ul>
         <li>If the "audio/aac" MIME-type is used, an MPEG Audio Frame is a sequence of bytes that conform to the adts_frame() syntax specified in Table 1.A.5 of <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=53943">ISO/IEC 14496-3:2009</a>.</li>
         <li>If the "audio/mpeg" MIME-type is used, an MPEG Audio Frame is a sequence of bytes that conform to the frame() syntax element specified in Section 2.4.1.2 of <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=22412">ISO/IEC 11172-3:1993</a> or the corresponding definition in <a href="http://www.iso.org/iso/catalogue_detail.htm?csnumber=26797">ISO/IEC 13818-3:1998</a>.</li>
@@ -386,7 +519,7 @@ table.simple {
 
       <section id="icecast" typeof="bibo:Chapter" resource="#icecast" property="bibo:hasPart">
         <h3 id="h-icecast" resource="#h-icecast"><span property="xhv:role" resource="xhv:heading"><span class="secno">4.1 </span>Icecast headers</span></h3>
-        <p>There is no normative spec for <a href="http://en.wikipedia.org/wiki/Icecast">Icecast</a>/<a href="http://en.wikipedia.org/wiki/SHOUTcast">SHOUTcast</a> headers, just <a href="http://forums.radiotoolbox.com/viewtopic.php?t=74">examples</a>. For the purpose of this specification, an <dfn id="icecast-header" data-dfn-for="" data-dfn-type="dfn">Icecast header</dfn> is defined as beginning with the 4 character sequence "ICY&nbsp;"(U+0049 I, U+0043 C, U+0059 Y, U+0020 SPACE) and ending with a pair of carriage-return line-feed sequences (U+000D CARRIAGE RETURN, U+000A LINE FEED, U+000D CARRIAGE RETURN, U+000A LINE FEED).</p>
+        <p>There is no normative spec for <a href="http://en.wikipedia.org/wiki/Icecast">Icecast</a>/<a href="http://en.wikipedia.org/wiki/SHOUTcast">SHOUTcast</a> headers, just <a href="http://forums.radiotoolbox.com/viewtopic.php?t=74">examples</a>. For the purpose of this specification, an <dfn id="icecast-header" data-dfn-type="dfn">Icecast header</dfn> is defined as beginning with the 4 character sequence "ICY&nbsp;"(U+0049 I, U+0043 C, U+0059 Y, U+0020 SPACE) and ending with a pair of carriage-return line-feed sequences (U+000D CARRIAGE RETURN, U+000A LINE FEED, U+000D CARRIAGE RETURN, U+000A LINE FEED).</p>
         <div class="note"><div class="note-title" aria-level="4" role="heading" id="h-note1"><span>Note</span></div><p class="">Icecast headers are allowed in the byte streams because some Icecast and SHOUTcast
           servers return a status line that looks like "ICY OK 200" instead of a standard HTTP status line.
           User-agent network stacks typically interpret this as an HTTP 0.9 response and include the
@@ -422,5 +555,5 @@ table.simple {
     </section> -->
   
 
-<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+<section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
 </dd></dl></section></section></body></html>

--- a/webm-byte-stream-format-respec.html
+++ b/webm-byte-stream-format-respec.html
@@ -34,7 +34,7 @@
       specStatus: "ED",
 
       // the specification's short name, as in http://www.w3.org/TR/short-name/
-      shortName: "",
+      shortName: "media-source", <!-- The registry does not have its own short name. -->
 
       // if there a publicly available Editor's Draft, this is the link
       edDraftURI: "https://w3c.github.io/media-source/webm-byte-stream-format.html",
@@ -83,6 +83,26 @@
 
       scheme: "https",
 
+      otherLinks: [{
+      key: 'Repository',
+      data: [{
+          value: 'We are on GitHub',
+          href: 'https://github.com/w3c/media-source/'
+        }, {
+          value: 'File a bug',
+          href: 'https://github.com/w3c/media-source/issues'
+        }, {
+          value: 'Commit history',
+          href: 'https://github.com/w3c/media-source/commits/gh-pages/webm-byte-stream-format-respec.html'
+        }]
+      },{
+        key: 'Mailing list',
+        data: [{
+          value: 'public-html-media@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+        }]
+      }],
+
       preProcess: [ mediaSourcePreProcessor ],
 
       // Empty definitions for objects declared in the document are here to
@@ -103,16 +123,23 @@
       };
     </script>
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <link rel="stylesheet" href="mse.css">
   </head>
   <body>
     <section id="abstract">
       This specification defines a <a href="http://www.w3.org/TR/media-source/">Media Source Extensions</a> byte stream format specification based on the WebM container format.
+    </section>
+
+    <section id="sotd">
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
     </section>
 
     <section id="introduction">

--- a/webm-byte-stream-format.html
+++ b/webm-byte-stream-format.html
@@ -9,10 +9,12 @@
 
     
     <!-- script to register bugs -->
+    <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
+    -->
 
     <style>/* --- ISSUES/NOTES --- */
 div.issue-title, div.note-title , div.ednote-title, div.warning-title {
@@ -198,7 +200,7 @@ table.simple {
 }
 </style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
   "specStatus": "ED",
-  "shortName": "",
+  "shortName": "media-source",
   "edDraftURI": "https://w3c.github.io/media-source/webm-byte-stream-format.html",
   "prevVersion": "http://www.w3.org/2013/12/byte-stream-format-registry/webm-byte-stream-format.html",
   "editors": [
@@ -235,6 +237,34 @@ table.simple {
   "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/40318/status",
   "noIDLIn": true,
   "scheme": "https",
+  "otherLinks": [
+    {
+      "key": "Repository",
+      "data": [
+        {
+          "value": "We are on GitHub",
+          "href": "https://github.com/w3c/media-source/"
+        },
+        {
+          "value": "File a bug",
+          "href": "https://github.com/w3c/media-source/issues"
+        },
+        {
+          "value": "Commit history",
+          "href": "https://github.com/w3c/media-source/commits/gh-pages/webm-byte-stream-format-respec.html"
+        }
+      ]
+    },
+    {
+      "key": "Mailing list",
+      "data": [
+        {
+          "value": "public-html-media@w3.org",
+          "href": "https://lists.w3.org/Archives/Public/public-html-media/"
+        }
+      ]
+    }
+  ],
   "preProcess": [
     null
   ],
@@ -272,7 +302,7 @@ table.simple {
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/media-source/webm-byte-stream-format.html">https://w3c.github.io/media-source/webm-byte-stream-format.html</a></dd>
       <dt>Latest published version:</dt>
-      <dd><a href="http://www.w3.org/TR//">http://www.w3.org/TR//</a></dd>
+      <dd><a href="http://www.w3.org/TR/media-source/">http://www.w3.org/TR/media-source/</a></dd>
     
     
       <dt>Latest editor's draft:</dt>
@@ -298,6 +328,54 @@ table.simple {
 </dd>
 
     
+    
+      
+        
+          <dt>Repository:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/">
+                      We are on GitHub
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/issues">
+                      File a bug
+                    </a>
+                  </dd>
+                
+             
+                
+                  <dd>
+                    <a href="https://github.com/w3c/media-source/commits/gh-pages/webm-byte-stream-format-respec.html">
+                      Commit history
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
+        
+          <dt>Mailing list:</dt>
+          
+             
+                
+                  <dd>
+                    <a href="https://lists.w3.org/Archives/Public/public-html-media/">
+                      public-html-media@w3.org
+                    </a>
+                  </dd>
+                
+             
+          
+        
+      
     
   </dl>
   
@@ -339,6 +417,9 @@ table.simple {
         
           
           
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+    
           
           
           <p>
@@ -410,6 +491,8 @@ table.simple {
     
   
 </section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#introduction" class="tocxref"><span class="secno">1. </span>Introduction</a></li><li class="tocline"><a href="#webm-mime-parameters" class="tocxref"><span class="secno">2. </span>MIME-type parameters</a></li><li class="tocline"><a href="#webm-init-segments" class="tocxref"><span class="secno">3. </span>Initialization Segments</a></li><li class="tocline"><a href="#webm-media-segments" class="tocxref"><span class="secno">4. </span>Media Segments</a></li><li class="tocline"><a href="#webm-random-access-points" class="tocxref"><span class="secno">5. </span>Random Access Points</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">6. </span>Conformance</a></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">7. </span>Acknowledgments</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li><li class="tocline"><a href="#informative-references" class="tocxref"><span class="secno">A.2 </span>Informative references</a></li></ul></li></ul></section>
+
+    
 
     <section id="introduction" typeof="bibo:Chapter" resource="#introduction" property="bibo:hasPart">
       <!--OddPage--><h2 id="h-introduction" resource="#h-introduction"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Introduction</span></h2>
@@ -535,6 +618,6 @@ table.simple {
     </section>
   
 
-<form id="bug-assist-form" action="//www.w3.org/Bugs/Public/enter_bug.cgi" target="_blank">See a problem? Select text and <input type="submit" accesskey="f" value="file a bug" style="font-family: Tahoma, sans-serif; font-size: 10px;"><input type="hidden" name="comment" value=""><input type="hidden" name="short_desc" value="[MSE] "><input type="hidden" name="product" value="HTML WG"><input type="hidden" name="component" value="Media Source Extensions">.</form><section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+<section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
 </dd></dl></section><section id="informative-references" typeof="bibo:Chapter" resource="#informative-references" property="bibo:hasPart"><h3 id="h-informative-references" resource="#h-informative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.2 </span>Informative references</span></h3><dl class="bibliography" resource=""><dt id="bib-INBANDTRACKS">[INBANDTRACKS]</dt><dd>Bob Lund; Silvia Pfeiffer. <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references"><cite>Sourcing In-band Media Resource Tracks from Media Containers into HTML</cite></a>. URL: <a href="http://dev.w3.org/html5/html-sourcing-inband-tracks/" property="dc:references">http://dev.w3.org/html5/html-sourcing-inband-tracks/</a>
 </dd></dl></section></section></body></html>


### PR DESCRIPTION
Includes previously missing sotd and abstract sections where necessary,
and removes unnecessary empty "SourceBuffer" entries in the local
respec definitionMap to net 0 respec errors for the updated respec
files in this change.