### PR TITLE
Fix typo introduced by removing the TrackDefault feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -872,7 +872,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Media Source Extensions</h1>
-    <h2 id="w3c-editor-s-draft-08-august-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-08-08">08 August 2016</time></h2>
+    <h2 id="w3c-editor-s-draft-09-august-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-08-09">09 August 2016</time></h2>
     <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="http://w3c.github.io/media-source/">http://w3c.github.io/media-source/</a></dd>
@@ -2613,7 +2613,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
                   <li>Let <var>audio byte stream track ID</var> be the
                     <a href="#track-id">Track ID</a> for the current track being processed.</li>
                   <li>Let <var>audio language</var> be a BCP 47 language tag for the language specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no language info is present.</li>
-                  <li>If <var>audio language</var> the 'und' BCP 47 value, then assign an empty string to <var>audio language</var>.</li>
+                  <li>If <var>audio language</var> equals the 'und' BCP 47 value, then assign an empty string to <var>audio language</var>.</li>
                   <li>Let <var>audio label</var> be a label specified in the <a href="#init-segment">initialization segment</a> for this track or an empty string if no label info is present.</li>
                   <li>Let <var>audio kinds</var> be a sequence of kind strings specified in the
                     <a href="#init-segment">initialization segment</a> for this track or a sequence with a single empty string element in it if no kind information is provided.</li>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -1461,7 +1461,7 @@ interface MediaSource : EventTarget {
                     <li>Let <var>audio language</var> be a BCP 47 language tag for the language
                       specified in the <a def-id="init-segment"></a> for this track or an empty string if no
                       language info is present.</li>
-                    <li>If <var>audio language</var> the 'und' BCP 47 value, then assign an empty string to <var>audio language</var>.</li>
+                    <li>If <var>audio language</var> equals the 'und' BCP 47 value, then assign an empty string to <var>audio language</var>.</li>
                     <li>Let <var>audio label</var> be a label specified in the <a def-id="init-segment"></a> for this track or an empty string if no
                       label info is present.</li>
                     <li>Let <var>audio kinds</var> be a sequence of kind strings specified in the


### PR DESCRIPTION
Commit ed76bbd8f9c827771ec80df05e10983b88ed0af8 introduced a typo.
This change adds the word "equals" where it was intended to be, in the
initialization segment received algorithm's processing of audio
language, when the inband language is the 'und' BCP 47 value.