### PR TITLE
Fix #152: Clarify note about text tracks in SourceBuffer.buffered

### DIFF
--- a/index.html
+++ b/index.html
@@ -872,7 +872,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
     </p>
     <h1 class="title p-name" id="title" property="dcterms:title">Media Source Extensions</h1>
-    <h2 id="w3c-editor-s-draft-17-august-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-08-17">17 August 2016</time></h2>
+    <h2 id="w3c-editor-s-draft-18-august-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-08-18">18 August 2016</time></h2>
     <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="http://w3c.github.io/media-source/">http://w3c.github.io/media-source/</a></dd>
@@ -2136,7 +2136,7 @@ interface <span class="idlInterfaceID">MediaSource</span> : <span class="idlSupe
               <ol>
                 <div class="note">
                   <div class="note-title marker" aria-level="4" role="heading" id="h-note33"><span>Note</span></div>
-                  <p class="">Text <a href="#track-buffer">track-buffers</a> are excluded from the buffered range calculation. They are not necessarily continuous, nor should any discontinuity within them trigger playback stall when the other media tracks are continuous over the same time range.</p>
+                  <p class="">Text <a href="#track-buffer">track-buffers</a> are included in the calculation of <var>highest end time</var>, above, but excluded from the buffered range calculation here. They are not necessarily continuous, nor should any discontinuity within them trigger playback stall when the other media tracks are continuous over the same time range.</p>
                 </div>
                 <li>Let <var>track ranges</var> equal the <a href="#track-buffer-ranges">track buffer ranges</a> for the current <a href="#track-buffer">track buffer</a>.</li>
                 <li>If <code><a href="#dom-readystate">readyState</a></code> is <code><a href="#idl-def-ReadyState.ended">"ended"</a></code>, then set the end time on the last range in <var>track ranges</var> to <var>highest end time</var>.</li>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -1003,7 +1003,7 @@ interface MediaSource : EventTarget {
             <li>Let <var>intersection ranges</var> equal a <a def-id="timerange"></a> object containing a single range from 0 to <var>highest end time</var>.</li>
             <li>For each audio and video <a def-id="track-buffer"></a> managed by this <a>SourceBuffer</a>, run the following steps:
               <ol>
-                <p class="note">Text <a def-id="track-buffer">track-buffers</a> are excluded from the buffered range calculation. They are not necessarily continuous, nor should any discontinuity within them trigger playback stall when the other media tracks are continuous over the same time range.</p>
+                <p class="note">Text <a def-id="track-buffer">track-buffers</a> are included in the calculation of <var>highest end time</var>, above, but excluded from the buffered range calculation here. They are not necessarily continuous, nor should any discontinuity within them trigger playback stall when the other media tracks are continuous over the same time range.</p>
                 <li>Let <var>track ranges</var> equal the <a def-id="track-buffer-ranges"></a> for the current <a def-id="track-buffer"></a>.</li>
                 <li>If <a def-id="readyState"></a> is <a def-id="ended"></a>, then set the end time on the last range in <var>track ranges</var> to <var>highest end time</var>.</li>
                 <li>Let <var>new intersection ranges</var> equal the intersection between the <var>intersection ranges</var> and the <var>track ranges</var>.</li>


### PR DESCRIPTION
I'll merge this shortly.