### PR TITLE
Fix #157: Remove 'audio/mp2t' from byte stream format registry

### DIFF
--- a/byte-stream-format-registry-respec.html
+++ b/byte-stream-format-registry-respec.html
@@ -3,7 +3,8 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Media Source Extensions Byte Stream Format Registry</title>
-    <script src="respec-w3c-common.js" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
+    <!--<script src="respec-w3c-common.js" class="remove"></script>-->
     <script src="media-source.js" class="remove"></script>
     <script class="remove">
       var respecConfig = {
@@ -182,7 +183,6 @@
           </tr>
           <tr>
             <td>
-              audio/mp2t<br>
               video/mp2t
             </td>
             <td><a href="mp2t-byte-stream-format.html">MPEG-2 Transport Streams Byte Stream Format</a></td>

--- a/byte-stream-format-registry.html
+++ b/byte-stream-format-registry.html
@@ -1,183 +1,342 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr" typeof="bibo:Document " prefix="bibo: http://purl.org/ontology/bibo/ w3p: http://www.w3.org/2001/02pd/rec54#">
-<head><meta lang="" property="dc:language" content="en">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Media Source Extensions Byte Stream Format Registry</title>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta lang="" property="dc:language" content="en">
+  <style>
+    /*
+
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
     
+    .hljs {
+      display: block;
+      overflow-x: auto;
+      padding: 0.5em;
+      color: #333;
+      background: #f8f8f8;
+    }
     
+    .hljs-comment,
+    .hljs-quote {
+      color: #998;
+      font-style: italic;
+    }
     
-    <!-- script to register bugs -->
-    <!-- Disabled unless/until it supports GitHub issues.
+    .hljs-keyword,
+    .hljs-selector-tag,
+    .hljs-subst {
+      color: #333;
+      font-weight: bold;
+    }
+    
+    .hljs-number,
+    .hljs-literal,
+    .hljs-variable,
+    .hljs-template-variable,
+    .hljs-tag .hljs-attr {
+      color: #008080;
+    }
+    
+    .hljs-string,
+    .hljs-doctag {
+      color: #d14;
+    }
+    
+    .hljs-title,
+    .hljs-section,
+    .hljs-selector-id {
+      color: #900;
+      font-weight: bold;
+    }
+    
+    .hljs-subst {
+      font-weight: normal;
+    }
+    
+    .hljs-type,
+    .hljs-class .hljs-title {
+      color: #458;
+      font-weight: bold;
+    }
+    
+    .hljs-tag,
+    .hljs-name,
+    .hljs-attribute {
+      color: #000080;
+      font-weight: normal;
+    }
+    
+    .hljs-regexp,
+    .hljs-link {
+      color: #009926;
+    }
+    
+    .hljs-symbol,
+    .hljs-bullet {
+      color: #990073;
+    }
+    
+    .hljs-built_in,
+    .hljs-builtin-name {
+      color: #0086b3;
+    }
+    
+    .hljs-meta {
+      color: #999;
+      font-weight: bold;
+    }
+    
+    .hljs-deletion {
+      background: #fdd;
+    }
+    
+    .hljs-addition {
+      background: #dfd;
+    }
+    
+    .hljs-emphasis {
+      font-style: italic;
+    }
+    
+    .hljs-strong {
+      font-weight: bold;
+    }
+  </style>
+  <style id="respec-mainstyle">
+    /*****************************************************************
+ * ReSpec 3 CSS
+ * Robin Berjon - http://berjon.com/
+ *****************************************************************/
+    /* Override code highlighter background */
+    
+    .hljs {
+      background: transparent !important;
+    }
+    /* --- INLINES --- */
+    
+    em.rfc2119 {
+      text-transform: lowercase;
+      font-variant: small-caps;
+      font-style: normal;
+      color: #900;
+    }
+    
+    h1 acronym,
+    h2 acronym,
+    h3 acronym,
+    h4 acronym,
+    h5 acronym,
+    h6 acronym,
+    a acronym,
+    h1 abbr,
+    h2 abbr,
+    h3 abbr,
+    h4 abbr,
+    h5 abbr,
+    h6 abbr,
+    a abbr {
+      border: none;
+    }
+    
+    dfn {
+      font-weight: bold;
+    }
+    
+    a.internalDFN {
+      color: inherit;
+      border-bottom: 1px solid #99c;
+      text-decoration: none;
+    }
+    
+    a.externalDFN {
+      color: inherit;
+      border-bottom: 1px dotted #ccc;
+      text-decoration: none;
+    }
+    
+    a.bibref {
+      text-decoration: none;
+    }
+    
+    cite .bibref {
+      font-style: normal;
+    }
+    
+    code {
+      color: #C83500;
+    }
+    
+    th code {
+      color: inherit;
+    }
+    /* --- TOC --- */
+    
+    .toc a,
+    .tof a {
+      text-decoration: none;
+    }
+    
+    a .secno,
+    a .figno {
+      color: #000;
+    }
+    
+    ul.tof,
+    ol.tof {
+      list-style: none outside none;
+    }
+    
+    .caption {
+      margin-top: 0.5em;
+      font-style: italic;
+    }
+    /* --- TABLE --- */
+    
+    table.simple {
+      border-spacing: 0;
+      border-collapse: collapse;
+      border-bottom: 3px solid #005a9c;
+    }
+    
+    .simple th {
+      background: #005a9c;
+      color: #fff;
+      padding: 3px 5px;
+      text-align: left;
+    }
+    
+    .simple th[scope="row"] {
+      background: inherit;
+      color: inherit;
+      border-top: 1px solid #ddd;
+    }
+    
+    .simple td {
+      padding: 3px 10px;
+      border-top: 1px solid #ddd;
+    }
+    
+    .simple tr:nth-child(even) {
+      background: #f0f6ff;
+    }
+    /* --- DL --- */
+    
+    .section dd> p:first-child {
+      margin-top: 0;
+    }
+    
+    .section dd> p:last-child {
+      margin-bottom: 0;
+    }
+    
+    .section dd {
+      margin-bottom: 1em;
+    }
+    
+    .section dl.attrs dd,
+    .section dl.eldef dd {
+      margin-bottom: 0;
+    }
+    
+    .respec-hidden {
+      display: none;
+    }
+    
+    @media print {
+      .removeOnSave {
+        display: none;
+      }
+    }
+  </style>
+  <title>Media Source Extensions Byte Stream Format Registry</title>
+
+  <!--<script src="respec-w3c-common.js" class="remove"></script>-->
+
+
+  <!-- script to register bugs -->
+  <!-- Disabled unless/until it supports GitHub issues.
     <script src="https://w3c.github.io/webcomponents/assets/scripts/bug-assist.js"></script>
     <meta name="bug.short_desc" content="[MSE] ">
     <meta name="bug.product" content="HTML WG">
     <meta name="bug.component" content="Media Source Extensions">
     -->
 
-    <link rel="stylesheet" href="mse.css">
+  <link rel="stylesheet" href="mse.css">
 
-    <style type="text/css">
-      #registry table { border-collapse: collapse; border-style: hidden hidden none hidden; }
-      #registry table thead, table tbody { border-bottom: solid; }
-      #registry table tbody th:first-child { border-left: solid; }
-      #registry table tbody th { text-align: left; }
-      #registry table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
-    </style>
-  <style>/*****************************************************************
- * ReSpec 3 CSS
- * Robin Berjon - http://berjon.com/
- *****************************************************************/
-
-/* --- INLINES --- */
-em.rfc2119 { 
-    text-transform:     lowercase;
-    font-variant:       small-caps;
-    font-style:         normal;
-    color:              #900;
-}
-
-h1 acronym, h2 acronym, h3 acronym, h4 acronym, h5 acronym, h6 acronym, a acronym,
-h1 abbr, h2 abbr, h3 abbr, h4 abbr, h5 abbr, h6 abbr, a abbr {
-    border: none;
-}
-
-dfn {
-    font-weight:    bold;
-}
-
-a.internalDFN {
-    color:  inherit;
-    border-bottom:  1px solid #99c;
-    text-decoration:    none;
-}
-
-a.externalDFN {
-    color:  inherit;
-    border-bottom:  1px dotted #ccc;
-    text-decoration:    none;
-}
-
-a.bibref {
-    text-decoration:    none;
-}
-
-cite .bibref {
-    font-style: normal;
-}
-
-code {
-    color:  #C83500;
-}
-
-/* --- TOC --- */
-.toc a, .tof a {
-    text-decoration:    none;
-}
-
-a .secno, a .figno {
-    color:  #000;
-}
-
-ul.tof, ol.tof {
-    list-style: none outside none;
-}
-
-.caption {
-    margin-top: 0.5em;
-    font-style:   italic;
-}
-
-/* --- TABLE --- */
-table.simple {
-    border-spacing: 0;
-    border-collapse:    collapse;
-    border-bottom:  3px solid #005a9c;
-}
-
-.simple th {
-    background: #005a9c;
-    color:  #fff;
-    padding:    3px 5px;
-    text-align: left;
-}
-
-.simple th[scope="row"] {
-    background: inherit;
-    color:  inherit;
-    border-top: 1px solid #ddd;
-}
-
-.simple td {
-    padding:    3px 10px;
-    border-top: 1px solid #ddd;
-}
-
-.simple tr:nth-child(even) {
-    background: #f0f6ff;
-}
-
-/* --- DL --- */
-.section dd > p:first-child {
-    margin-top: 0;
-}
-
-.section dd > p:last-child {
-    margin-bottom: 0;
-}
-
-.section dd {
-    margin-bottom:  1em;
-}
-
-.section dl.attrs dd, .section dl.eldef dd {
-    margin-bottom:  0;
-}
-
-@media print {
-    .removeOnSave {
-        display: none;
+  <style type="text/css">
+    #registry table {
+      border-collapse: collapse;
+      border-style: hidden hidden none hidden;
     }
-}
-</style><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/W3C-ED"><!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]--><script id="initialUserConfig" type="application/json">{
-  "specStatus": "ED",
-  "shortName": "media-source",
-  "edDraftURI": "https://w3c.github.io/media-source/byte-stream-format-registry.html",
-  "prevVersion": "http://www.w3.org/2013/12/byte-stream-format-registry/",
-  "editors": [
-    {
-      "name": "Matthew Wolenetz",
-      "url": "",
-      "company": "Google Inc.",
-      "companyURL": "http://www.google.com/"
-    },
-    {
-      "name": "Jerry Smith",
-      "url": "",
-      "company": "Microsoft Corporation",
-      "companyURL": "http://www.microsoft.com/"
-    },
-    {
-      "name": "Aaron Colwell (until April 2015)",
-      "url": "",
-      "company": "Google Inc.",
-      "companyURL": "http://www.google.com/"
+    
+    #registry table thead,
+    table tbody {
+      border-bottom: solid;
     }
-  ],
-  "mseDefGroupName": "byte-stream-format-registry",
-  "mseUnusedGroupNameExcludeList": [
-    "media-source"
-  ],
-  "mseContributors": [],
-  "wg": "HTML Media Extensions Working Group",
-  "wgURI": "http://www.w3.org/html/wg/",
-  "wgPublicList": "public-html-media",
-  "wgPatentURI": "http://www.w3.org/2004/01/pp-impl/40318/status",
-  "noIDLIn": true,
-  "scheme": "https",
-  "otherLinks": [
+    
+    #registry table tbody th:first-child {
+      border-left: solid;
+    }
+    
+    #registry table tbody th {
+      text-align: left;
+    }
+    
+    #registry table td,
+    table th {
+      border-left: solid;
+      border-right: solid;
+      border-bottom: solid thin;
+      vertical-align: top;
+      padding: 0.2em;
+    }
+  </style>
+  <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED">
+  <!--[if lt IE 9]><script src='https://www.w3.org/2008/site/js/html5shiv.js'></script><![endif]-->
+  <meta name="generator" content="ReSpec 5.0.0">
+  <script id="initialUserConfig" type="application/json">
     {
-      "key": "Repository",
-      "data": [
+      "specStatus": "ED",
+      "shortName": "media-source",
+      "edDraftURI": "https://w3c.github.io/media-source/byte-stream-format-registry.html",
+      "prevVersion": "https://www.w3.org/2013/12/byte-stream-format-registry/",
+      "editors": [
+      {
+        "name": "Matthew Wolenetz",
+        "url": "",
+        "company": "Google Inc.",
+        "companyURL": "http://www.google.com/"
+      },
+      {
+        "name": "Jerry Smith",
+        "url": "",
+        "company": "Microsoft Corporation",
+        "companyURL": "http://www.microsoft.com/"
+      },
+      {
+        "name": "Aaron Colwell (until April 2015)",
+        "url": "",
+        "company": "Google Inc.",
+        "companyURL": "http://www.google.com/"
+      }],
+      "mseDefGroupName": "byte-stream-format-registry",
+      "mseUnusedGroupNameExcludeList": [
+        "media-source"
+      ],
+      "mseContributors": [],
+      "wg": "HTML Media Extensions Working Group",
+      "wgURI": "https://www.w3.org/html/wg/",
+      "wgPublicList": "public-html-media",
+      "wgPatentURI": "https://www.w3.org/2004/01/pp-impl/40318/status",
+      "noIDLIn": true,
+      "scheme": "https",
+      "otherLinks": [
+      {
+        "key": "Repository",
+        "data": [
         {
           "value": "We are on GitHub",
           "href": "https://github.com/w3c/media-source/"
@@ -189,332 +348,245 @@ table.simple {
         {
           "value": "Commit history",
           "href": "https://github.com/w3c/media-source/commits/gh-pages/byte-stream-format-registry-respec.html"
-        }
-      ]
-    },
-    {
-      "key": "Mailing list",
-      "data": [
+        }]
+      },
+      {
+        "key": "Mailing list",
+        "data": [
         {
           "value": "public-html-media@w3.org",
           "href": "https://lists.w3.org/Archives/Public/public-html-media/"
-        }
+        }]
+      }],
+      "preProcess": [
+        null,
+        null
+      ],
+      "definitionMap":
+      {},
+      "postProcess": [
+        null
       ]
     }
-  ],
-  "preProcess": [
-    null,
-    null
-  ],
-  "definitionMap": {},
-  "postProcess": [
-    null
-  ]
-}</script></head>
-  <body class="h-entry" role="document" id="respecDocument"><div class="head" role="contentinfo" id="respecHeader">
-  <p>
-      
-        
-            <a class="logo" href="http://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/Icons/w3c_home" alt="W3C"></a>
-            
-            
-        
-      
-  </p>
-  <h1 class="title p-name" id="title" property="dcterms:title">Media Source Extensions Byte Stream Format Registry</h1>
-  
-  <h2 id="w3c-editor-s-draft-10-august-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-08-10">10 August 2016</time></h2>
-  <dl>
-    
+  </script>
+</head>
+<body class="h-entry toc-inline" role="document" id="respecDocument">
+  <div class="head" role="contentinfo" id="respecHeader">
+    <p>
+      <a class="logo" href="https://www.w3.org/"><img width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C"></a>
+    </p>
+    <h1 class="title p-name" id="title" property="dcterms:title">Media Source Extensions Byte Stream Format Registry</h1>
+    <h2 id="w3c-editor-s-draft-09-september-2016"><abbr title="World Wide Web Consortium">W3C</abbr> Editor's Draft <time property="dcterms:issued" class="dt-published" datetime="2016-09-09">09 September 2016</time></h2>
+    <dl>
       <dt>This version:</dt>
       <dd><a class="u-url" href="https://w3c.github.io/media-source/byte-stream-format-registry.html">https://w3c.github.io/media-source/byte-stream-format-registry.html</a></dd>
       <dt>Latest published version:</dt>
-      <dd><a href="http://www.w3.org/TR/media-source/">http://www.w3.org/TR/media-source/</a></dd>
-    
-    
+      <dd><a href="https://www.w3.org/TR/media-source/">https://www.w3.org/TR/media-source/</a></dd>
       <dt>Latest editor's draft:</dt>
       <dd><a href="https://w3c.github.io/media-source/byte-stream-format-registry.html">https://w3c.github.io/media-source/byte-stream-format-registry.html</a></dd>
-    
-    
-    
-    
-    
-      
-    
-    
-    
-    <dt>Editors:</dt>
-    <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Matthew Wolenetz</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
-<span property="rdf:rest" resource="_:editor1"></span>
-</dd>
-<dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Jerry Smith</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
-<span property="rdf:rest" resource="_:editor2"></span>
-</dd>
-<dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
-<span property="rdf:rest" resource="rdf:nil"></span>
-</dd>
+      <dt>Editors:</dt>
+      <dd class="p-author h-card vcard" property="bibo:editor" resource="_:editor0"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Matthew Wolenetz</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+        <span property="rdf:rest" resource="_:editor1"></span>
+      </dd>
+      <dd class="p-author h-card vcard" resource="_:editor1"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Jerry Smith</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.microsoft.com/">Microsoft Corporation</a></span>
+        <span property="rdf:rest" resource="_:editor2"></span>
+      </dd>
+      <dd class="p-author h-card vcard" resource="_:editor2"><span property="rdf:first" typeof="foaf:Person"><span property="foaf:name" class="p-name fn">Aaron Colwell (until April 2015)</span>, <a property="foaf:workplaceHomepage" class="p-org org h-org h-card" href="http://www.google.com/">Google Inc.</a></span>
+        <span property="rdf:rest" resource="rdf:nil"></span>
+      </dd>
 
-    
-    
-      
-        
-          <dt>Repository:</dt>
-          
-             
-                
-                  <dd>
-                    <a href="https://github.com/w3c/media-source/">
+      <dt>Repository:</dt>
+      <dd>
+        <a href="https://github.com/w3c/media-source/">
                       We are on GitHub
                     </a>
-                  </dd>
-                
-             
-                
-                  <dd>
-                    <a href="https://github.com/w3c/media-source/issues">
+      </dd>
+      <dd>
+        <a href="https://github.com/w3c/media-source/issues">
                       File a bug
                     </a>
-                  </dd>
-                
-             
-                
-                  <dd>
-                    <a href="https://github.com/w3c/media-source/commits/gh-pages/byte-stream-format-registry-respec.html">
+      </dd>
+      <dd>
+        <a href="https://github.com/w3c/media-source/commits/gh-pages/byte-stream-format-registry-respec.html">
                       Commit history
                     </a>
-                  </dd>
-                
-             
-          
-        
-      
-        
-          <dt>Mailing list:</dt>
-          
-             
-                
-                  <dd>
-                    <a href="https://lists.w3.org/Archives/Public/public-html-media/">
+      </dd>
+      <dt>Mailing list:</dt>
+      <dd>
+        <a href="https://lists.w3.org/Archives/Public/public-html-media/">
                       public-html-media@w3.org
                     </a>
-                  </dd>
-                
-             
-          
-        
-      
-    
-  </dl>
-  
-  
-  
-  
-    
-      <p class="copyright">
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        2016
-        
-        <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
-        (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). 
-        
-        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-        
-          
-            <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a>
-          
-        
-        rules apply.
-      </p>
-    
-  
-  <hr title="Separator for header">
-</div>
+      </dd>
+    </dl>
+    <p class="copyright">
+      <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2016
 
-    <section id="abstract" class="introductory" property="dc:abstract"><h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
-      <p>This specification defines the byte stream formats for use with the <a href="index.html#">Media Source Extensions</a> specification.</p>
-    </section><section id="sotd" class="introductory"><h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
-  
-    
-      
-        <p>
-          <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="http://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at http://www.w3.org/TR/.</em>
-        </p>
-        
-          
-          
-      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
-      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
-    
-          
-          
-          <p>
-            This document was published by the <a href="http://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft.
-            
-            
-              If you wish to make comments regarding this document, please send them to
-              <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>
-              (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
-              <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>).
-            
-            
-            
-            
-            
-              
-              All comments are welcome.
-              
-            
-          </p>
-          
-          
-          
-          
-            <p>
-              Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
-              Membership. This is a draft document and may be updated, replaced or obsoleted by other
-              documents at any time. It is inappropriate to cite this document as other than work in
-              progress.
-            </p>
-          
-          
-          
-          <p>
-            
-              This document was produced by
-              
-              a group
-               operating under the
-              <a id="sotd_patent" property="w3p:patentRules" href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
+      <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+      <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+      <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
+      <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+      <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+    </p>
+    <hr title="Separator for header">
+  </div>
+
+  <section id="abstract" class="introductory" property="dc:abstract">
+    <h2 id="h-abstract" resource="#h-abstract"><span property="xhv:role" resource="xhv:heading">Abstract</span></h2>
+    <p>This specification defines the byte stream formats for use with the <a href="index.html#">Media Source Extensions</a> specification.</p>
+  </section>
+
+  <section id="sotd" class="introductory">
+    <h2 id="h-sotd" resource="#h-sotd"><span property="xhv:role" resource="xhv:heading">Status of This Document</span></h2>
+    <p>
+      <em>This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at https://www.w3.org/TR/.</em>
+    </p>
+
+    <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
+    <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+
+    <p>
+      This document was published by the <a href="https://www.w3.org/html/wg/">HTML Media Extensions Working Group</a> as an Editor's Draft. If you wish to make comments regarding this document, please send them to
+      <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a> (<a href="mailto:public-html-media-request@w3.org?subject=subscribe">subscribe</a>,
+      <a href="https://lists.w3.org/Archives/Public/public-html-media/">archives</a>). All comments are welcome.
+    </p>
+    <p>
+      Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.
+    </p>
+    <p>
+      This document was produced by a group operating under the
+      <a id="sotd_patent" property="w3p:patentRules" href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 <abbr title="World Wide Web Consortium">W3C</abbr> Patent
               Policy</a>.
-            
-            
-            
-              
-                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
-                disclosures</a>
-              
-              made in connection with the deliverables of
-              
-              the group; that page also includes
-              
-              instructions for disclosing a patent. An individual who has actual knowledge of a patent
-              which the individual believes contains
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+      <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="https://www.w3.org/2004/01/pp-impl/40318/status" rel="disclosure">public list of any patent
+                disclosures</a> made in connection with the deliverables of the group; that page also includes instructions for disclosing a patent. An individual who has actual knowledge of a patent which the individual believes contains
+      <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
               Claim(s)</a> must disclose the information in accordance with
-              <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
+      <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
               6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-            
-            
-          </p>
-          
-            <p>This document is governed by the <a id="w3c_process_revision" href="http://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
-            </p>
-          
-          
-        
-      
-    
-  
-</section><section id="toc"><h2 class="introductory" id="h-toc" resource="#h-toc"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2><ul class="toc" role="directory"><li class="tocline"><a href="#purpose" class="tocxref"><span class="secno">1. </span>Purpose</a></li><li class="tocline"><a href="#organization" class="tocxref"><span class="secno">2. </span>Organization</a></li><li class="tocline"><a href="#entry-requirements" class="tocxref"><span class="secno">3. </span>Registration Entry Requirements</a></li><li class="tocline"><a href="#registry" class="tocxref"><span class="secno">4. </span>Registry</a></li><li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">5. </span>Conformance</a></li><li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a><ul class="toc"><li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li></ul></li></ul></section>
+    </p>
+    <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/2015/Process-20150901/">1 September 2015 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+    </p>
 
-    
+  </section>
+  <nav id="toc">
+    <h2 class="introductory" id="table-of-contents" resource="#table-of-contents"><span property="xhv:role" resource="xhv:heading">Table of Contents</span></h2>
+    <ol class="toc" role="directory">
+      <li class="tocline"><a href="#purpose" class="tocxref"><span class="secno">1. </span>Purpose</a></li>
+      <li class="tocline"><a href="#organization" class="tocxref"><span class="secno">2. </span>Organization</a></li>
+      <li class="tocline"><a href="#entry-requirements" class="tocxref"><span class="secno">3. </span>Registration Entry Requirements</a></li>
+      <li class="tocline"><a href="#registry" class="tocxref"><span class="secno">4. </span>Registry</a></li>
+      <li class="tocline"><a href="#conformance" class="tocxref"><span class="secno">5. </span>Conformance</a></li>
+      <li class="tocline"><a href="#references" class="tocxref"><span class="secno">A. </span>References</a>
+        <ol class="toc">
+          <li class="tocline"><a href="#normative-references" class="tocxref"><span class="secno">A.1 </span>Normative references</a></li>
+        </ol>
+      </li>
+    </ol>
+  </nav>
 
-    <section id="purpose" typeof="bibo:Chapter" resource="#purpose" property="bibo:hasPart">
-      <!--OddPage--><h2 id="h-purpose" resource="#h-purpose"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Purpose</span></h2>
-      <p>This registry is intended to enhance interoperability among implementations and users of
-        <code><a href="index.html#idl-def-SourceBuffer" class="idlType">SourceBuffer</a></code> objects described in the
-        <a href="index.html#">Media Source Extensions</a>(MSE) specification. In particular, this registry provides the means (1) to identify
-        and avoid MIME-type collisions among byte stream formats, and (2) to disclose information about byte stream formats accepted by MSE
-        implementations to promote interoperability.
-    </p></section>
 
-    <section id="organization" typeof="bibo:Chapter" resource="#organization" property="bibo:hasPart">
-      <!--OddPage--><h2 id="h-organization" resource="#h-organization"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Organization</span></h2>
-      <p>The registry maintains a mapping between MIME-type/subtype pairs and byte stream format specifications. The byte stream format specifications describe the
-        structure and semantics of byte streams accepted by <code><a href="index.html#idl-def-SourceBuffer" class="idlType">SourceBuffer</a></code> objects
-        created with the associated MIME-type/subtype pair.</p>
-      <p>This registry is not intended to include any information on whether a byte stream format is encumbered by intellectual property claims. Implementors and users
-        are advised to seek appropriate legal counsel in this matter if they intend to implement or use a specific byte stream format.</p>
+
+  <section id="purpose" typeof="bibo:Chapter" resource="#purpose" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-purpose" resource="#h-purpose"><span property="xhv:role" resource="xhv:heading"><span class="secno">1. </span>Purpose</span></h2>
+    <p>This registry is intended to enhance interoperability among implementations and users of
+      <code><a href="index.html#idl-def-SourceBuffer" class="idlType">SourceBuffer</a></code> objects described in the
+      <a href="index.html#">Media Source Extensions</a>(MSE) specification. In particular, this registry provides the means (1) to identify and avoid MIME-type collisions among byte stream formats, and (2) to disclose information about byte stream formats accepted by MSE implementations to promote interoperability.
+    </p>
+  </section>
+
+  <section id="organization" typeof="bibo:Chapter" resource="#organization" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-organization" resource="#h-organization"><span property="xhv:role" resource="xhv:heading"><span class="secno">2. </span>Organization</span></h2>
+    <p>The registry maintains a mapping between MIME-type/subtype pairs and byte stream format specifications. The byte stream format specifications describe the structure and semantics of byte streams accepted by <code><a href="index.html#idl-def-SourceBuffer" class="idlType">SourceBuffer</a></code> objects created with the associated MIME-type/subtype pair.</p>
+    <p>This registry is not intended to include any information on whether a byte stream format is encumbered by intellectual property claims. Implementors and users are advised to seek appropriate legal counsel in this matter if they intend to implement or use a specific byte stream format.</p>
+  </section>
+
+  <section id="entry-requirements" typeof="bibo:Chapter" resource="#entry-requirements" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-entry-requirements" resource="#h-entry-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Registration Entry Requirements</span></h2>
+    <ol>
+      <li>Each entry <em class="rfc2119" title="MUST">MUST</em> include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it <em class="rfc2119" title="SHOULD">SHOULD</em> use the MIME-type/subtype pairs typically used for the file format.</li>
+      <li>Each entry <em class="rfc2119" title="MUST">MUST</em> include a <var><a href="index.html#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> value that <em class="rfc2119" title="MUST">MUST</em> be used by
+        <code><a href="index.html#idl-def-SourceBuffer" class="idlType">SourceBuffer</a></code> when handling the byte stream format.</li>
+      <li>Each entry <em class="rfc2119" title="MUST">MUST</em> include a link that references a publically available specification. It is recommended that such a specification be made available without cost (other than reasonable shipping and handling if not available by online means).</li>
+      <li>Each entry <em class="rfc2119" title="MUST">MUST</em> comply with all requirements outlined in the <a href="index.html#byte-stream-formats">byte stream formats section</a> of the <a href="index.html#">Media Source Extensions</a> specification.</li>
+      <li>Candidate entries <em class="rfc2119" title="MUST">MUST</em> be announced on <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>(<a href="mailto:public-html-media-request@w3.org">subscribe</a>,
+        <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>) so they can be discussed and evaluated for compliance before being added to the registry.
+      </li>
+    </ol>
+    <p>If a registration fails to satisfy a mandatory requirement specified above, then it <em class="rfc2119" title="MAY">MAY</em> be removed from the registry (without prejudice).
+    </p>
+  </section>
+
+  <section id="registry" typeof="bibo:Chapter" resource="#registry" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-registry" resource="#h-registry"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Registry</span></h2>
+    <table>
+      <thead>
+        <tr>
+          <th>MIME type/subtype</th>
+          <th>Public Specification(s)</th>
+          <th>Generate Timestamps Flag</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            audio/webm<br> video/webm
+          </td>
+          <td><a href="webm-byte-stream-format.html">WebM Byte Stream Format</a></td>
+          <td>false</td>
+        </tr>
+        <tr>
+          <td>
+            audio/mp4<br> video/mp4
+          </td>
+          <td><a href="isobmff-byte-stream-format.html">ISO BMFF Byte Stream Format</a></td>
+          <td>false</td>
+        </tr>
+        <tr>
+          <td>
+            video/mp2t
+          </td>
+          <td><a href="mp2t-byte-stream-format.html">MPEG-2 Transport Streams Byte Stream Format</a></td>
+          <td>false</td>
+        </tr>
+        <tr>
+          <td>
+            audio/mpeg<br> audio/aac
+          </td>
+          <td><a href="mpeg-audio-byte-stream-format.html">MPEG Audio Byte Stream Format</a></td>
+          <td>true</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Conformance</span></h2>
+    <p>
+      As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
+    </p>
+    <p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
+    </p>
+  </section>
+
+
+  <section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart">
+    <!--OddPage-->
+    <h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2>
+
+    <section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart">
+      <h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3>
+      <dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt>
+        <dd>S. Bradner. IETF. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
+        </dd>
+      </dl>
     </section>
-
-    <section id="entry-requirements" typeof="bibo:Chapter" resource="#entry-requirements" property="bibo:hasPart">
-      <!--OddPage--><h2 id="h-entry-requirements" resource="#h-entry-requirements"><span property="xhv:role" resource="xhv:heading"><span class="secno">3. </span>Registration Entry Requirements</span></h2>
-      <ol>
-        <li>Each entry <em class="rfc2119" title="MUST">MUST</em> include a unique MIME-type/subtype pair. If the byte stream format is derived-from an existing file format, then it <em class="rfc2119" title="SHOULD">SHOULD</em> use the
-          MIME-type/subtype pairs typically used for the file format.</li>
-        <li>Each entry <em class="rfc2119" title="MUST">MUST</em> include a <var><a href="index.html#sourcebuffer-generate-timestamps-flag">generate timestamps flag</a></var> value that <em class="rfc2119" title="MUST">MUST</em> be used by
-            <code><a href="index.html#idl-def-SourceBuffer" class="idlType">SourceBuffer</a></code> when handling the byte stream format.</li>
-        <li>Each entry <em class="rfc2119" title="MUST">MUST</em> include a link that references a publically available specification. It is recommended that such a specification be made available
-          without cost (other than reasonable shipping and handling if not available by online means).</li>
-        <li>Each entry <em class="rfc2119" title="MUST">MUST</em> comply with all requirements outlined in the <a href="index.html#byte-stream-formats">byte stream formats section</a>
-          of the <a href="index.html#">Media Source Extensions</a> specification.</li>
-        <li>Candidate entries <em class="rfc2119" title="MUST">MUST</em> be announced on <a href="mailto:public-html-media@w3.org">public-html-media@w3.org</a>(<a href="mailto:public-html-media-request@w3.org">subscribe</a>,
-          <a href="http://lists.w3.org/Archives/Public/public-html-media/">archives</a>) so they can be discussed and evaluated for compliance before being added to the
-          registry.</li>
-      </ol>
-      <p>If a registration fails to satisfy a mandatory requirement specified above, then it <em class="rfc2119" title="MAY">MAY</em> be removed from the registry (without prejudice).
-    </p></section>
-
-    <section id="registry" typeof="bibo:Chapter" resource="#registry" property="bibo:hasPart">
-      <!--OddPage--><h2 id="h-registry" resource="#h-registry"><span property="xhv:role" resource="xhv:heading"><span class="secno">4. </span>Registry</span></h2>
-      <table>
-        <thead>
-          <tr>
-            <th>MIME type/subtype</th>
-            <th>Public Specification(s)</th>
-            <th>Generate Timestamps Flag</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              audio/webm<br>
-              video/webm
-            </td>
-            <td><a href="webm-byte-stream-format.html">WebM Byte Stream Format</a></td>
-            <td>false</td>
-          </tr>
-          <tr>
-            <td>
-              audio/mp4<br>
-              video/mp4
-            </td>
-            <td><a href="isobmff-byte-stream-format.html">ISO BMFF Byte Stream Format</a></td>
-            <td>false</td>
-          </tr>
-          <tr>
-            <td>
-              audio/mp2t<br>
-              video/mp2t
-            </td>
-            <td><a href="mp2t-byte-stream-format.html">MPEG-2 Transport Streams Byte Stream Format</a></td>
-            <td>false</td>
-          </tr>
-          <tr>
-            <td>
-              audio/mpeg<br>
-              audio/aac
-            </td>
-            <td><a href="mpeg-audio-byte-stream-format.html">MPEG Audio Byte Stream Format</a></td>
-            <td>true</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-    <section id="conformance" typeof="bibo:Chapter" resource="#conformance" property="bibo:hasPart"><!--OddPage--><h2 id="h-conformance" resource="#h-conformance"><span property="xhv:role" resource="xhv:heading"><span class="secno">5. </span>Conformance</span></h2>
-<p>
-  As well as sections marked as non-normative, all authoring guidelines, diagrams, examples,
-  and notes in this specification are non-normative. Everything else in this specification is
-  normative.
-</p>
-<p id="respecRFC2119">The key words <em class="rfc2119" title="MAY">MAY</em>, <em class="rfc2119" title="MUST">MUST</em>, and <em class="rfc2119" title="SHOULD">SHOULD</em> are 
-  to be interpreted as described in [<cite><a class="bibref" href="#bib-RFC2119">RFC2119</a></cite>].
-</p>
-</section>
-  
-
-<section id="references" class="appendix" typeof="bibo:Chapter" resource="#references" property="bibo:hasPart"><!--OddPage--><h2 id="h-references" resource="#h-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A. </span>References</span></h2><section id="normative-references" typeof="bibo:Chapter" resource="#normative-references" property="bibo:hasPart"><h3 id="h-normative-references" resource="#h-normative-references"><span property="xhv:role" resource="xhv:heading"><span class="secno">A.1 </span>Normative references</span></h3><dl class="bibliography" resource=""><dt id="bib-RFC2119">[RFC2119]</dt><dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119" property="dc:requires">https://tools.ietf.org/html/rfc2119</a>
-</dd></dl></section></section></body></html>
+  </section>
+  <p role="navigation" id="back-to-top"><a href="#toc"><abbr title="Back to Top">↑</abbr></a></p>
+  <script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Following the example of the main MSE spec, this commit also includes
linking to the current w3c-respec-common.js in the format registry
respec source because saving the snapshot was otherwise failing with the
w3c-respec.common.js in the repo.