### PR TITLE
Adjust process-related info for Media WG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# HTML Working Group
+# Media Source Extensions and related specifications
 
 Contributions to this repository are intended to become part of Recommendation-track documents 
-governed by the [W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
-[Document License](http://www.w3.org/Consortium/Legal/copyright-documents). To contribute, you must 
-either participate in the relevant W3C Working Group or make a non-member patent licensing
- commitment.
+governed by the [W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy/) and
+the [W3C Software and Document License](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
+To contribute, you must either participate in the relevant W3C Working Group or
+make a non-member patent licensing commitment.
 
 If you are not the sole contributor to a contribution (pull request), please identify all 
 contributors in the pull request's body or in subsequent comments.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,2 +1,2 @@
-All documents in this Repository are licensed by contributors under the [W3C Document
-License](http://www.w3.org/Consortium/Legal/copyright-documents).
+All documents in this Repository are licensed by contributors under the
+[W3C Software and Document License](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).

--- a/w3c.json
+++ b/w3c.json
@@ -1,6 +1,9 @@
 {
-  "group":     80485
-, "contacts":  ["plehegar"]
-, "policy":    "open"
-, "repo-type": "rec-track"
+  "group":     115198,
+  "contacts":  [
+    "tidoust",
+    "jernoble",
+    "mounirlamouri"
+  ],
+  "repo-type": "rec-track"
 }


### PR DESCRIPTION
Per [charter](https://www.w3.org/2019/05/media-wg-charter.html#licensing), the Media WG will use the W3C Software and Document license for all its deliverables, not the more restrictive W3C Document license (FYI, the MSE Recommendation was published under the W3C Software and Document License already)

The update also adjusts the w3c.json file (used internally to track W3C repos) to point to the Media WG, which now owns the specs.

The boilerplate in each spec will need to be adjusted as well. I propose to do that in a separate update.