### PR TITLE
Link ED to the Media WG and update SOTD section

### DIFF
--- a/byte-stream-format-registry-respec.html
+++ b/byte-stream-format-registry-respec.html
@@ -40,20 +40,20 @@
       ],
 
       // name of the WG
-      wg:           "HTML Media Extensions Working Group",
+      wg:           "Media Working Group",
 
       // URI of the public WG page
-      wgURI:        "https://www.w3.org/html/wg/",
+      wgURI:        "https://www.w3.org/media-wg/",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-html-media",
+      wgPublicList: "public-media-wg",
 
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
-      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/40318/status",
+      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
       noIDLIn: true,
 
@@ -74,8 +74,8 @@
       },{
         key: 'Mailing list',
         data: [{
-          value: 'public-html-media@w3.org',
-          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+          value: 'public-media-wg@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-media-wg/'
         }]
       }],
 
@@ -114,8 +114,8 @@
     </section>
 
     <section id="sotd">
-      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
-      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
     </section>
 
     <section id="purpose">

--- a/isobmff-byte-stream-format-respec.html
+++ b/isobmff-byte-stream-format-respec.html
@@ -60,20 +60,20 @@
       ],
 
       // name of the WG
-      wg:           "HTML Media Extensions Working Group",
+      wg:           "Media Working Group",
 
       // URI of the public WG page
-      wgURI:        "https://www.w3.org/html/wg/",
+      wgURI:        "https://www.w3.org/media-wg/",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-html-media",
+      wgPublicList: "public-media-wg",
 
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
-      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/40318/status",
+      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
       noIDLIn: true,
 
@@ -94,8 +94,8 @@
       },{
         key: 'Mailing list',
         data: [{
-          value: 'public-html-media@w3.org',
-          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+          value: 'public-media-wg@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-media-wg/'
         }]
       }],
 
@@ -140,8 +140,8 @@
     </section>
 
     <section id="sotd">
-      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
-      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
     </section>
 
     <section id="introduction">

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -70,20 +70,20 @@
       ],
 
       // name of the WG
-      wg:           "HTML Media Extensions Working Group",
+      wg:           "Media Working Group",
 
       // URI of the public WG page
-      wgURI:        "https://www.w3.org/html/wg/",
+      wgURI:        "https://www.w3.org/media-wg/",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-html-media",
+      wgPublicList: "public-media-wg",
       license: 'w3c-software-doc',
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
-      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/40318/status",
+      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
       lcEnd: "2016-08-10",
       prEnd: "2016-11-01",
@@ -108,8 +108,8 @@
     },{
       key: 'Mailing list',
       data: [{
-        value: 'public-html-media@w3.org',
-        href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+        value: 'public-media-wg@w3.org',
+        href: 'https://lists.w3.org/Archives/Public/public-media-wg/'
       }]
     },{
       key: 'Implementation',
@@ -171,12 +171,8 @@
   <body>
 
     <section id="sotd">
-        <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports</a>. New features for this specification are expected to be incubated in the <a href='https://www.w3.org/community/wicg/'>Web Platform Incubator Community Group</a>.</p>
-        <p>One editorial issue (<a href='https://github.com/w3c/media-source/issues/168'>removing the exposure of <code>createObjectURL(mediaSource)</code> in workers</a>) was addressed since the previous publication. For the list of changes done since the previous version, see the <a href='https://github.com/w3c/media-source/commits/gh-pages'>commits</a>.</p>
-        <p>
-          By publishing this Recommendation, W3C expects the functionality specified in this Recommendation will not be affected by changes to File API. The Working Group will continue to track these specifications.
-        </p>
-
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
     </section>
 
     <section id="abstract">

--- a/mp2t-byte-stream-format-respec.html
+++ b/mp2t-byte-stream-format-respec.html
@@ -58,20 +58,20 @@
       ],
 
       // name of the WG
-      wg:           "HTML Media Extensions Working Group",
+      wg:           "Media Working Group",
 
       // URI of the public WG page
-      wgURI:        "https://www.w3.org/html/wg/",
+      wgURI:        "https://www.w3.org/media-wg/",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-html-media",
+      wgPublicList: "public-media-wg",
 
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
-      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/40318/status",
+      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
       noIDLIn: true,
 
@@ -92,8 +92,8 @@
       },{
         key: 'Mailing list',
         data: [{
-          value: 'public-html-media@w3.org',
-          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+          value: 'public-media-wg@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-media-wg/'
         }]
       }],
 
@@ -132,8 +132,8 @@
     </section>
 
     <section id="sotd">
-      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
-      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
     </section>
 
     <section id="introduction">

--- a/mpeg-audio-byte-stream-format-respec.html
+++ b/mpeg-audio-byte-stream-format-respec.html
@@ -57,20 +57,20 @@
       ],
 
       // name of the WG
-      wg:           "HTML Media Extensions Working Group",
+      wg:           "Media Working Group",
 
       // URI of the public WG page
-      wgURI:        "https://www.w3.org/html/wg/",
+      wgURI:        "https://www.w3.org/media-wg/",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-html-media",
+      wgPublicList: "public-media-wg",
 
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
-      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/40318/status",
+      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
       noIDLIn: true,
 
@@ -91,8 +91,8 @@
       },{
         key: 'Mailing list',
         data: [{
-          value: 'public-html-media@w3.org',
-          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+          value: 'public-media-wg@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-media-wg/'
         }]
       }],
 
@@ -122,8 +122,8 @@
     </section>
 
     <section id="sotd">
-      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
-      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
     </section>
 
     <section id="introduction">

--- a/webm-byte-stream-format-respec.html
+++ b/webm-byte-stream-format-respec.html
@@ -66,20 +66,20 @@
       ],
 
       // name of the WG
-      wg:           "HTML Media Extensions Working Group",
+      wg:           "Media Working Group",
 
       // URI of the public WG page
-      wgURI:        "https://www.w3.org/html/wg/",
+      wgURI:        "https://www.w3.org/media-wg/",
 
       // name (without the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-html-media",
+      wgPublicList: "public-media-wg",
 
       // URI of the patent status for this WG, for Rec-track documents
       // !!!! IMPORTANT !!!!
       // This is important for Rec-track documents, do not copy a patent URI from a random
       // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
       // Team Contact.
-      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/40318/status",
+      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
 
       noIDLIn: true,
 
@@ -100,8 +100,8 @@
       },{
         key: 'Mailing list',
         data: [{
-          value: 'public-html-media@w3.org',
-          href: 'https://lists.w3.org/Archives/Public/public-html-media/'
+          value: 'public-media-wg@w3.org',
+          href: 'https://lists.w3.org/Archives/Public/public-media-wg/'
         }]
       }],
 
@@ -146,8 +146,8 @@
     </section>
 
     <section id="sotd">
-      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>; there may also be open bugs in the <a href="http://w3.org/brief/Mjcw">previous bug tracker</a>.</p>
-      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should join the mailing list mentioned below and take part in the discussions.</p>
+      <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>.</p>
+      <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
     </section>
 
     <section id="introduction">


### PR DESCRIPTION
The update refreshes Respec's config to link the Editor's Drafts to the Media Working Group from now on.

It also refreshes the Status of this Document section to:
- remove the link to the now defunct previous bug tracker
- encourage interested parties to track the GitHub repository (instead of the mailing-list) where most of the work happens.