### PR TITLE
Add support for PR-Previews for the main MSE spec

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,4 @@
+{
+    "src_file": "media-source-respec.html",
+    "type": "respec"
+}


### PR DESCRIPTION
This only adds previews and diffs for the main MSE spec src file (media-source-respec.html), not the various bytestream format registry and format specs. See https://github.com/tobie/pr-preview/issues/18 for potentially adding support for previewing PRs for multiple specs within a repo.