### PR TITLE
Fixes #197 - add application/mp4 to registry and isobmff bytestream format

### DIFF
--- a/byte-stream-format-registry-respec.html
+++ b/byte-stream-format-registry-respec.html
@@ -176,7 +176,8 @@
           <tr>
             <td>
               audio/mp4<br>
-              video/mp4
+              video/mp4<br>
+              application/mp4
             </td>
             <td><a def-id="byte-stream-format-registry-isobmff"></a> [[!MSE-FORMAT-ISOBMFF]]</td>
             <td>false</td>

--- a/isobmff-byte-stream-format-respec.html
+++ b/isobmff-byte-stream-format-respec.html
@@ -155,7 +155,7 @@
     <section id="mime-parameters">
       <h2>MIME-type parameters</h2>
       <p>This section specifies the parameters that can be used in the MIME-type passed to <a def-id="isTypeSupported"></a> or <a def-id="addSourceBuffer"></a>.</p>
-      <p>MIME-types for this specification MUST conform to the rules outlined for "audio/mp4" and "video/mp4" in <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
+      <p>MIME-types for this specification MUST conform to the rules outlined for "audio/mp4", "video/mp4" and "application/mp4" in <a href="http://tools.ietf.org/html/rfc6381">RFC 6381</a>.
       </p>
       <div class="note">Implementations MAY only implement a subset of the codecs and profiles mentioned in the RFC.</div>
     </section>


### PR DESCRIPTION
Changes as proposed in #197 

I only changed the `-respec.html` files as there didn't seem to be a documented build process. I wondered if it was the same as the old encrypted-media process, but the diffs were huge.

I left the existing ReSpec and syntax errors for the editors to consider.