### PR TITLE
Use absolute URL for MSE in xref script, and fix broken fragments

### DIFF
--- a/media-source.js
+++ b/media-source.js
@@ -156,17 +156,17 @@
     'timestampOffset': { func: idlref_helper, fragment: 'dom-sourcebuffer-timestampoffset', link_text: 'timestampOffset',  },
     'appendWindowStart': { func: idlref_helper, fragment: 'dom-sourcebuffer-appendwindowstart', link_text: 'appendWindowStart', },
     'appendWindowEnd': { func: idlref_helper, fragment: 'dom-sourcebuffer-appendwindowend', link_text: 'appendWindowEnd', },
-    'AppendMode-segments': { func: idlref_helper, fragment: 'idl-def-AppendMode.segments', link_text: '"segments"',  },
-    'AppendMode-sequence': { func: idlref_helper, fragment: 'idl-def-AppendMode.sequence', link_text: '"sequence"',  },
+    'AppendMode-segments': { func: idlref_helper, fragment: 'dom-appendmode-segments', link_text: '"segments"',  },
+    'AppendMode-sequence': { func: idlref_helper, fragment: 'dom-appendmode-sequence', link_text: '"sequence"',  },
     'mode': { func: idlref_helper, fragment: 'dom-sourcebuffer-mode', link_text: 'mode',  },
 
     'SourceBufferList-length': { func: idlref_helper, fragment: 'dom-sourcebufferlist-length', link_text: 'length',  },
     'createObjectURL': { func: idlref_helper, fragment: 'dom-url-createobjecturl', link_text: 'createObjectURL()',  },
-    'open': { func: idlref_helper, fragment: 'idl-def-ReadyState.open', link_text: '"open"',  },
-    'closed': { func: idlref_helper, fragment: 'idl-def-ReadyState.closed', link_text: '"closed"',  },
-    'ended': { func: idlref_helper, fragment: 'idl-def-ReadyState.ended', link_text: '"ended"',  },
-    'network': { func: idlref_helper, fragment: 'idl-def-EndOfStreamError.network', link_text: '"network"',  },
-    'decode': { func: idlref_helper, fragment: 'idl-def-EndOfStreamError.decode', link_text: '"decode"',  },
+    'open': { func: idlref_helper, fragment: 'dom-readystate-open', link_text: '"open"',  },
+    'closed': { func: idlref_helper, fragment: 'dom-readystate-closed', link_text: '"closed"',  },
+    'ended': { func: idlref_helper, fragment: 'dom-readystate-ended', link_text: '"ended"',  },
+    'network': { func: idlref_helper, fragment: 'dom-endofstreamerror-network', link_text: '"network"',  },
+    'decode': { func: idlref_helper, fragment: 'dom-endofstreamerror-decode', link_text: '"decode"',  },
 
     'updatestart': { func: eventref_helper, fragment: 'updatestart', link_text: 'updatestart',  },
     'update': { func: eventref_helper, fragment: 'update', link_text: 'update', },
@@ -428,7 +428,7 @@
     // main MSE spec, which would otherwise conflict if included in the main MSE
     // spec, are added in this utility function. Don't call this function from
     // the main MSE respec.
-    externalClassInfo.SourceBuffer = { spec: 'mse', fragment: 'idl-def-SourceBuffer' };
+    externalClassInfo.SourceBuffer = { spec: 'mse', fragment: 'idl-def-sourcebuffer' };
   }
 
   function mediaSourcePreProcessor() {
@@ -449,11 +449,8 @@
 
     for (var x in groupBaseURLs) {
       if (groupBaseURLs[x] == original_MSE_spec_url && specStatus == "ED") {
-        MSE_spec_url = "index.html";
-        groupBaseURLs[x] = MSE_spec_url;
-
         // Refer to the local file rather than the published path.
-        var file = "index.html";
+        var file = "https://w3c.github.io/media-source/index.html";
         MSE_spec_url = file;
         groupBaseURLs[x] = MSE_spec_url;
         // Refer to the Web IDL Editor’s Draft from Editor’s Drafts of this spec.


### PR DESCRIPTION
The `media-source.js` script is used to manage cross-references in MSE specs. To be able to reference this script from dedicated repositories for byte stream formats and registry specifications (see #239), the script must use an absolute URL for the ED of the main Media Source Extensions spec.

The update also fixes a few broken fragments (naming rules have changed in Respec in the meantime).