### PR TITLE
Switch to Process 2020

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -3,8 +3,8 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title>Media Source Extensions™</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
-    <!--<script src="respec-w3c-common.js" class="remove"></script>-->
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
     <script src="media-source.js" class="remove"></script>
     <script class="remove">
       var respecConfig = {
@@ -72,26 +72,9 @@
       ],
 
       // name of the WG
-      wg:           "Media Working Group",
+      group: "media",
 
-      // URI of the public WG page
-      wgURI:        "https://www.w3.org/media-wg/",
-
-      // name (without the @w3c.org) of the public mailing to which comments are due
-      wgPublicList: "public-media-wg",
-      license: 'w3c-software-doc',
-      // URI of the patent status for this WG, for Rec-track documents
-      // !!!! IMPORTANT !!!!
-      // This is important for Rec-track documents, do not copy a patent URI from a random
-      // document unless you know what you're doing. If in doubt ask your friendly neighbourhood
-      // Team Contact.
-      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/115198/status",
-
-      lcEnd: "2016-08-10",
-      prEnd: "2016-11-01",
-      implementationReportURI: "http://tidoust.github.io/media-source-testcoverage/",
-
-      noIDLIn: true,
+      implementationReportURI: "https://tidoust.github.io/media-source-testcoverage/",
 
       scheme: "https",
 
@@ -130,21 +113,6 @@
       preProcess: [ mediaSourcePreProcessor ],
 
       postProcess: [ mediaSourcePostProcessor ],
-
-      localBiblio: {
-          "INBANDTRACKS": {
-              title: "Sourcing In-band Media Resource Tracks from Media Containers into HTML",
-              href: "https://dev.w3.org/html5/html-sourcing-inband-tracks/",
-              authors: ["Bob Lund", "Silvia Pfeiffer"],
-              publisher: "W3C",
-          },
-          "MEDIA-PLAYBACK-QUALITY": {
-              title: "Media Playback Quality",
-              href: "https://wicg.github.io/media-playback-quality/",
-              authors: ["Mounir Lamouri"],
-              publisher: "W3C",
-          }
-       }
       };
     </script>
 
@@ -310,8 +278,8 @@
     </section>
 
     <section id="mediasource">
-      <h2>MediaSource Object</h2>
-      <p>The MediaSource object represents a source of media data for an HTMLMediaElement. It keeps track of the <a def-id="readyState"></a> for this source as well as a list of <a>SourceBuffer</a> objects that can be used to add media data to the presentation. MediaSource objects are created by the web application and then attached to an HTMLMediaElement. The application uses the <a>SourceBuffer</a> objects in <a def-id="sourceBuffers"></a> to add media data to this source. The HTMLMediaElement fetches this media data from the <a>MediaSource</a> object when it is needed during playback.</p>
+      <h2><dfn>MediaSource</dfn> Object</h2>
+      <p>The MediaSource object represents a source of media data for an HTMLMediaElement. It keeps track of the {{MediaSource/readyState}} for this source as well as a list of <a>SourceBuffer</a> objects that can be used to add media data to the presentation. MediaSource objects are created by the web application and then attached to an HTMLMediaElement. The application uses the <a>SourceBuffer</a> objects in <a def-id="sourceBuffers"></a> to add media data to this source. The HTMLMediaElement fetches this media data from the <a>MediaSource</a> object when it is needed during playback.</p>
 
       <p>Each <a>MediaSource</a> object has a <dfn id="live-seekable-range">live seekable range</dfn> variable that stores a <a def-id="normalized-timeranges-object"></a>.  This variable is initialized to an empty <a def-id="timeranges"></a> object when the <a>MediaSource</a> object is created, is maintained by <a def-id="setLiveSeekableRange"></a> and <a def-id="clearLiveSeekableRange"></a>, and is used in <a href="#htmlmediaelement-extensions">HTMLMediaElement Extensions</a> to modify <a def-id="hme-seekable"></a> behavior.</p>
 
@@ -357,8 +325,8 @@ interface MediaSource : EventTarget {
 };</pre>
       <section>
         <h3>Attributes</h3>
-        <dl class="attributes" data-dfn-for="MediaSource" data-link-for="MediaSource"><dt><dfn><code>sourceBuffers</code></dfn> of type <span class="idlAttrType"><a>SourceBufferList</a></span>, readonly       </dt><dd>
-          Contains the list of <a>SourceBuffer</a> objects associated with this <a>MediaSource</a>. When <a def-id="readyState"></a> equals <a def-id="closed"></a> this list will be empty. Once <a def-id="readyState"></a> transitions to <a def-id="open"></a> SourceBuffer objects can be added to this list by using <a def-id="addSourceBuffer"></a>.
+        <dl class="attributes" data-dfn-for="MediaSource"><dt><dfn><code>sourceBuffers</code></dfn> of type <span class="idlAttrType"><a>SourceBufferList</a></span>, readonly       </dt><dd>
+          Contains the list of <a>SourceBuffer</a> objects associated with this <a>MediaSource</a>. When {{MediaSource/readyState}} equals <a def-id="closed"></a> this list will be empty. Once {{MediaSource/readyState}} transitions to <a def-id="open"></a> SourceBuffer objects can be added to this list by using <a def-id="addSourceBuffer"></a>.
         </dd><dt><dfn><code>activeSourceBuffers</code></dfn> of type <span class="idlAttrType"><a>SourceBufferList</a></span>, readonly       </dt><dd>
           <p>Contains the subset of <a def-id="sourceBuffers"></a> that are providing the
             <a def-id="videoref" name="dom-videotrack-selected">selected video track</a>, the
@@ -372,19 +340,19 @@ interface MediaSource : EventTarget {
           </p>
           <p class="note">The <a href="#active-source-buffer-changes">Changes to selected/enabled track state</a> section describes how this attribute gets
             updated.</p>
-        </dd><dt><dfn><code>readyState</code></dfn> of type <span class="idlAttrType"><a>ReadyState</a></span>, readonly       </dt><dd>
-          <p>Indicates the current state of the <a>MediaSource</a> object. When the <a>MediaSource</a> is created <a def-id="readyState"></a> MUST be set to <a def-id="closed"></a>.
+        </dd><dt><dfn><code>readyState</code></dfn> of type {{ReadyState}}, readonly       </dt><dd>
+          <p>Indicates the current state of the <a>MediaSource</a> object. When the <a>MediaSource</a> is created {{MediaSource/readyState}} MUST be set to <a def-id="closed"></a>.
         </p></dd><dt><dfn><code>duration</code></dfn> of type <span class="idlAttrType"><a>unrestricted double</a></span></dt><dd>
           <p>Allows the web application to set the presentation duration. The duration is initially set to NaN when the <a>MediaSource</a> object is created.</p>
           <p>On getting, run the following steps:</p>
           <ol>
-            <li>If the <a def-id="readyState"></a> attribute is <a def-id="closed"></a> then return NaN and abort these steps.</li>
+            <li>If the {{MediaSource/readyState}} attribute is <a def-id="closed"></a> then return NaN and abort these steps.</li>
             <li>Return the current value of the attribute.</li>
           </ol>
           <p>On setting, run the following steps:</p>
           <ol>
             <li>If the value being set is negative or NaN then throw a <a def-id="type-error"></a> exception and abort these steps.</li>
-            <li>If the <a def-id="readyState"></a> attribute is not <a def-id="open"></a> then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
+            <li>If the {{MediaSource/readyState}} attribute is not <a def-id="open"></a> then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>If the <a def-id="updating"></a> attribute equals true on any <a>SourceBuffer</a> in <a def-id="sourceBuffers"></a>, then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>Run the <a def-id="duration-change-algorithm"></a> with <var>new duration</var> set to the value being assigned to this attribute.
               <p class="note">The <a def-id="duration-change-algorithm"></a> will adjust <var>new duration</var> higher if there is any currently buffered coded frame with a higher end time.</p>
@@ -410,7 +378,7 @@ interface MediaSource : EventTarget {
                 playback.
               </p>
             </li>
-            <li>If the <a def-id="readyState"></a> attribute is not in the <a def-id="open"></a> state then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
+            <li>If the {{MediaSource/readyState}} attribute is not in the <a def-id="open"></a> state then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>Create a new <a>SourceBuffer</a> object and associated resources.</li>
             <li>Set the <a def-id="generate-timestamps-flag"></a> on the new object to the value in the
                "Generate Timestamps Flag" column of the byte stream format registry [[MSE-REGISTRY]] entry
@@ -529,7 +497,7 @@ interface MediaSource : EventTarget {
           <p>Signals the end of the stream.</p>
 
           <ol class="method-algorithm">
-            <li>If the <a def-id="readyState"></a> attribute is not in the <a def-id="open"></a> state then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
+            <li>If the {{MediaSource/readyState}} attribute is not in the <a def-id="open"></a> state then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>If the <a def-id="updating"></a> attribute equals true on any <a>SourceBuffer</a> in <a def-id="sourceBuffers"></a>, then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>Run the <a def-id="end-of-stream-algorithm"></a> with the <var>error</var> parameter set to <var>error</var>.</li>
           </ol>
@@ -537,7 +505,7 @@ interface MediaSource : EventTarget {
 
           <p>Updates the <a def-id="live-seekable-range"></a> variable used in <a href="#htmlmediaelement-extensions">HTMLMediaElement Extensions</a> to modify <a def-id="hme-seekable"></a> behavior.</p>
           <ol class="method-algorithm">
-            <li>If the <a def-id="readyState"></a> attribute is not <a def-id="open"></a> then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
+            <li>If the {{MediaSource/readyState}} attribute is not <a def-id="open"></a> then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>If <var>start</var> is negative or greater than <var>end</var>, then throw a <a def-id="type-error"></a> exception and abort these steps.</li>
             <li>Set <a def-id="live-seekable-range"></a> to be a new <a def-id="normalized-timeranges-object"></a> containing a single range whose start position is <var>start</var> and end position is <var>end</var>.
           </li></ol>
@@ -574,7 +542,7 @@ interface MediaSource : EventTarget {
           <p>Updates the <a def-id="live-seekable-range"></a> variable used in <a href="#htmlmediaelement-extensions">HTMLMediaElement Extensions</a> to modify <a def-id="hme-seekable"></a> behavior.</p>
 
           <ol class="method-algorithm">
-            <li>If the <a def-id="readyState"></a> attribute is not <a def-id="open"></a> then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
+            <li>If the {{MediaSource/readyState}} attribute is not <a def-id="open"></a> then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>If <a def-id="live-seekable-range"></a> contains a range, then set <a def-id="live-seekable-range"></a> to be a new empty <a def-id="timeranges"></a> object.
           </li></ol>
         <div><em>No parameters.</em></div><div><em>Return type: </em><a>void</a></div></dd><dt><dfn><code>isTypeSupported</code></dfn>, static</dt><dd>
@@ -611,17 +579,17 @@ interface MediaSource : EventTarget {
             <tr>
               <td><a def-id="eventdfn">sourceopen</a></td>
               <td><code>Event</code></td>
-              <td><a def-id="readyState"></a> transitions from <a def-id="closed"></a> to <a def-id="open"></a> or from <a def-id="ended"></a> to <a def-id="open"></a>.</td>
+              <td>{{MediaSource/readyState}} transitions from <a def-id="closed"></a> to <a def-id="open"></a> or from <a def-id="ended"></a> to <a def-id="open"></a>.</td>
             </tr>
             <tr>
               <td><a def-id="eventdfn">sourceended</a></td>
               <td><code>Event</code></td>
-              <td><a def-id="readyState"></a> transitions from <a def-id="open"></a> to <a def-id="ended"></a>.</td>
+              <td>{{MediaSource/readyState}} transitions from <a def-id="open"></a> to <a def-id="ended"></a>.</td>
             </tr>
             <tr>
               <td><a def-id="eventdfn">sourceclose</a></td>
               <td><code>Event</code></td>
-              <td><a def-id="readyState"></a> transitions from <a def-id="open"></a> to <a def-id="closed"></a> or <a def-id="ended"></a> to <a def-id="closed"></a>.</td>
+              <td>{{MediaSource/readyState}} transitions from <a def-id="open"></a> to <a def-id="closed"></a> or <a def-id="ended"></a> to <a def-id="closed"></a>.</td>
             </tr>
           </tbody>
         </table>
@@ -641,13 +609,13 @@ interface MediaSource : EventTarget {
           <p class="note">The <a def-id="resource-fetch-algorithm"></a>'s first step is expected to eventually align with selecting local mode for URL records whose objects are media provider objects. The intent is that if the HTMLMediaElement's <code>src</code> attribute or selected child <code>&lt;source&gt;</code>'s <code>src</code> attribute is a <code>blob:</code> URL matching a <a def-id="MediaSource-object-URL"></a> when the respective <code>src</code> attribute was last changed, then that MediaSource object is used as the media provider object and current media resource in the local mode logic in the <a def-id="resource-fetch-algorithm"></a>. This also means that the remote mode logic that includes observance of any preload attribute is skipped when a MediaSource object is attached. Even with that eventual change to [[HTML]], the execution of the following steps at the beginning of the local mode logic is still required when the current media resource is a MediaSource object.</p>
           <p class="note">Relative to the action which triggered the media element's resource selection algorithm, these steps are asynchronous. The resource fetch algorithm is run after the task that invoked the resource selection algorithm is allowed to continue and a stable state is reached. Implementations may delay the steps in the "<i>Otherwise</i>" clause, below, until the MediaSource object is ready for use.</p>
           <dl class="switch">
-            <dt>If <a def-id="readyState"></a> is NOT set to <a def-id="closed"></a></dt>
+            <dt>If {{MediaSource/readyState}} is NOT set to <a def-id="closed"></a></dt>
             <dd>Run the <a def-id="media-data-cannot-be-fetched"></a> steps of the <a def-id="resource-fetch-algorithm"></a>'s <a def-id="media-data-processing-steps-list"></a>.</dd>
             <dt>Otherwise</dt>
             <dd>
               <ol>
                 <li>Set the media element's <a def-id="delaying-the-load-event-flag"></a> to false.</li>
-                <li>Set the <a def-id="readyState"></a> attribute to <a def-id="open"></a>.</li>
+                <li>Set the {{MediaSource/readyState}} attribute to <a def-id="open"></a>.</li>
                 <li>
                   <a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="sourceopen"></a> at the <a>MediaSource</a>.</li>
                 <li>Continue the <a def-id="resource-fetch-algorithm"></a> by running the remaining <a def-id="Otherwise-mode-is-local"></a> steps, with these clarifications:
@@ -667,7 +635,7 @@ interface MediaSource : EventTarget {
           <p>The following steps are run in any case where the media element is going to transition to <a def-id="videoref" name="dom-htmlmediaelement-network_empty">NETWORK_EMPTY</a> and <a def-id="queue-a-task-to-fire-an-event-named"></a> <a def-id="videoref" name="eventdef-media-emptied">emptied</a> at the media element. These steps SHOULD be run right before the transition.</p>
 
           <ol>
-            <li>Set the <a def-id="readyState"></a> attribute to <a def-id="closed"></a>.</li>
+            <li>Set the {{MediaSource/readyState}} attribute to <a def-id="closed"></a>.</li>
             <li>Update <a def-id="duration"></a> to NaN.</li>
             <li>Remove all the <a>SourceBuffer</a> objects from <a def-id="activeSourceBuffers"></a>.</li>
             <li>
@@ -705,7 +673,7 @@ interface MediaSource : EventTarget {
                 </dd>
                 <dt>Otherwise</dt>
                 <dd>Continue
-                <p class="note">If the <a def-id="readyState"></a> attribute is <a def-id="ended"></a> and the <var>new playback position</var> is within a <a def-id="timerange"></a> currently in <a def-id="hme-buffered"></a>, then the seek operation must continue to completion here even if one or more currently selected or enabled track buffers' largest range end timestamp is less than <var>new playback position</var>. This condition should only occur due to logic in <a def-id="buffered"></a> when <a def-id="readyState"></a> is <a def-id="ended"></a>.</p>
+                <p class="note">If the {{MediaSource/readyState}} attribute is <a def-id="ended"></a> and the <var>new playback position</var> is within a <a def-id="timerange"></a> currently in <a def-id="hme-buffered"></a>, then the seek operation must continue to completion here even if one or more currently selected or enabled track buffers' largest range end timestamp is less than <var>new playback position</var>. This condition should only occur due to logic in <a def-id="buffered"></a> when {{MediaSource/readyState}} is <a def-id="ended"></a>.</p>
                 </dd>
               </dl>
             </li>
@@ -877,7 +845,7 @@ interface MediaSource : EventTarget {
           <p>This algorithm gets called when the application signals the end of stream via an <a def-id="endOfStream"></a> call or an algorithm needs to
             signal a decode error. This algorithm takes an <var>error</var> parameter that indicates whether an error will be signalled.</p>
           <ol>
-            <li>Change the <a def-id="readyState"></a> attribute value to <a def-id="ended"></a>.</li>
+            <li>Change the {{MediaSource/readyState}} attribute value to <a def-id="ended"></a>.</li>
             <li>
               <a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="sourceended"></a> at the <a>MediaSource</a>.</li>
             <li><dl class="switch">
@@ -923,7 +891,7 @@ interface MediaSource : EventTarget {
     </section>
 
     <section id="sourcebuffer">
-      <h2>SourceBuffer Object</h2>
+      <h2><dfn>SourceBuffer</dfn> Object</h2>
 
 
 <pre class="idl">enum AppendMode {
@@ -958,7 +926,7 @@ interface SourceBuffer : EventTarget {
     undefined appendBuffer (BufferSource data);
     undefined abort ();
     undefined remove (double start, unrestricted double end);
-};</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="SourceBuffer" data-link-for="SourceBuffer"><dt><dfn><code>mode</code></dfn> of type <span class="idlAttrType"><a>AppendMode</a></span></dt><dd>
+};</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="SourceBuffer"><dt><dfn><code>mode</code></dfn> of type <a>AppendMode</a></dt><dd>
           <p>Controls how a sequence of <a def-id="media-segments"></a> are handled. This attribute is initially set by <a def-id="addSourceBuffer"></a> after the object is created.</p>
           <p>On getting, Return the initial value or the last value that was successfully set.</p>
           <p>On setting, run the following steps:</p>
@@ -970,9 +938,9 @@ interface SourceBuffer : EventTarget {
               <a def-id="AppendMode-segments"></a>, then throw a <a def-id="type-error"></a>
               exception and abort these steps.</li>
             <li>
-              <p>If the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> is in the <a def-id="ended"></a> state then run the following steps:</p>
+              <p>If the {{MediaSource/readyState}} attribute of the <a def-id="parent-media-source"></a> is in the <a def-id="ended"></a> state then run the following steps:</p>
               <ol>
-                <li>Set the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> to <a def-id="open"></a></li>
+                <li>Set the {{MediaSource/readyState}} attribute of the <a def-id="parent-media-source"></a> to <a def-id="open"></a></li>
                 <li><a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="sourceopen"></a> at the <a def-id="parent-media-source"></a>.</li>
               </ol>
             </li>
@@ -996,7 +964,7 @@ interface SourceBuffer : EventTarget {
                 <p class="note">Text <a def-id="track-buffer">track-buffers</a> are included in the calculation of <var>highest end time</var>, above, but excluded from the buffered range calculation here. They are not necessarily continuous, nor should any discontinuity within them trigger playback stall when the other media tracks are continuous over the same time range.</p>
               <ol>
                 <li>Let <var>track ranges</var> equal the <a def-id="track-buffer-ranges"></a> for the current <a def-id="track-buffer"></a>.</li>
-                <li>If <a def-id="readyState"></a> is <a def-id="ended"></a>, then set the end time on the last range in <var>track ranges</var> to <var>highest end time</var>.</li>
+                <li>If {{MediaSource/readyState}} is <a def-id="ended"></a>, then set the end time on the last range in <var>track ranges</var> to <var>highest end time</var>.</li>
                 <li>Let <var>new intersection ranges</var> equal the intersection between the <var>intersection ranges</var> and the <var>track ranges</var>.</li>
                 <li>Replace the ranges in <var>intersection ranges</var> with the <var>new intersection ranges</var>.</li>
               </ol>
@@ -1015,9 +983,9 @@ interface SourceBuffer : EventTarget {
             <li>If this object has been removed from the <a def-id="sourceBuffers"></a> attribute of the <a def-id="parent-media-source"></a>, then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>If the <a def-id="updating"></a> attribute equals true, then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>
-              <p>If the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> is in the <a def-id="ended"></a> state then run the following steps:</p>
+              <p>If the {{MediaSource/readyState}} attribute of the <a def-id="parent-media-source"></a> is in the <a def-id="ended"></a> state then run the following steps:</p>
               <ol>
-                <li>Set the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> to <a def-id="open"></a></li>
+                <li>Set the {{MediaSource/readyState}} attribute of the <a def-id="parent-media-source"></a> to <a def-id="open"></a></li>
                 <li><a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="sourceopen"></a> at the <a def-id="parent-media-source"></a>.</li>
               </ol>
             </li>
@@ -1081,7 +1049,7 @@ interface SourceBuffer : EventTarget {
 
           <ol class="method-algorithm">
             <li>If this object has been removed from the <a def-id="sourceBuffers"></a> attribute of the <a def-id="parent-media-source"></a> then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
-            <li>If the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> is not in the <a def-id="open"></a> state then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
+            <li>If the {{MediaSource/readyState}} attribute of the <a def-id="parent-media-source"></a> is not in the <a def-id="open"></a> state then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>If the <a def-id="range-removal"></a> algorithm is running, then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>If the <a def-id="updating"></a> attribute equals true, then run the following steps:
               <ol>
@@ -1104,10 +1072,10 @@ interface SourceBuffer : EventTarget {
             <li>If <var>start</var> is negative or greater than <a def-id="duration"></a>, then throw a <a def-id="type-error"></a> exception and abort these steps.</li>
             <li>If <var>end</var> is less than or equal to <var>start</var> or <var>end</var> equals NaN, then throw a <a def-id="type-error"></a> exception and abort these steps.</li>
             <li>
-              <p>If the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> is in the <a def-id="ended"></a> state then run
+              <p>If the {{MediaSource/readyState}} attribute of the <a def-id="parent-media-source"></a> is in the <a def-id="ended"></a> state then run
                 the following steps:</p>
               <ol>
-                <li>Set the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> to <a def-id="open"></a></li>
+                <li>Set the {{MediaSource/readyState}} attribute of the <a def-id="parent-media-source"></a> to <a def-id="open"></a></li>
                 <li><a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="sourceopen"></a> at the <a def-id="parent-media-source"></a>.</li>
               </ol>
             </li>
@@ -1361,9 +1329,9 @@ interface SourceBuffer : EventTarget {
             <li>If the <a def-id="updating"></a> attribute equals true, then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>If the <a def-id="hme-error"></a> attribute is not null, then throw an <a def-id="invalid-state-error"></a> exception and abort these steps.</li>
             <li>
-              <p>If the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> is in the <a def-id="ended"></a> state then run the following steps:</p>
+              <p>If the {{MediaSource/readyState}} attribute of the <a def-id="parent-media-source"></a> is in the <a def-id="ended"></a> state then run the following steps:</p>
               <ol>
-                <li>Set the <a def-id="readyState"></a> attribute of the <a def-id="parent-media-source"></a> to <a def-id="open"></a>
+                <li>Set the {{MediaSource/readyState}} attribute of the <a def-id="parent-media-source"></a> to <a def-id="open"></a>
                 </li>
                 <li>
                   <a def-id="Queue-a-task-to-fire-an-event-named"></a> <a def-id="sourceopen"></a> at the <a def-id="parent-media-source"></a>.</li>
@@ -2028,7 +1996,7 @@ interface SourceBuffer : EventTarget {
     </section>
 
     <section id="sourcebufferlist">
-      <h2>SourceBufferList Object</h2>
+      <h2><dfn>SourceBufferList</dfn> Object</h2>
       <p>SourceBufferList is a simple container object for <a>SourceBuffer</a> objects. It provides read-only array access and fires events when the list is modified.</p>
 <pre class="idl">[Exposed=Window]
 interface SourceBufferList : EventTarget {
@@ -2161,7 +2129,7 @@ partial interface URL {
             <li>For each <a>SourceBuffer</a> object in <a def-id="activeSourceBuffers"></a> run the following steps:
               <ol>
                 <li>Let <var>source ranges</var> equal the ranges returned by the <a def-id="buffered"></a> attribute on the current <a>SourceBuffer</a>.</li>
-                <li>If <a def-id="readyState"></a> is <a def-id="ended"></a>, then set the end time on the last range in <var>source ranges</var> to
+                <li>If {{MediaSource/readyState}} is <a def-id="ended"></a>, then set the end time on the last range in <var>source ranges</var> to
                   <var>highest end time</var>.</li>
                 <li>Let <var>new intersection ranges</var> equal the intersection between the <var>intersection ranges</var> and the <var>source ranges</var>.</li>
                 <li>Replace the ranges in <var>intersection ranges</var> with the <var>new intersection ranges</var>.</li>
@@ -2226,7 +2194,7 @@ partial interface URL {
       <p>This section provides general requirements for all byte stream format specifications:</p>
       <ul>
         <li>A byte stream format specification MUST define <a def-id="init-segments"></a> and <a def-id="media-segments"></a>.</li>
-        <li>A byte stream format SHOULD provide references for sourcing <a>AudioTrack</a>, <a>VideoTrack</a>, and <a>TextTrack</a> attribute values
+        <li>A byte stream format SHOULD provide references for sourcing {{AudioTrack}}, {{VideoTrack}}, and {{TextTrack}} attribute values
           from data in <a def-id="init-segments"></a>.
           <p class="note">If the byte stream format covers a format similar to one covered in the in-band tracks spec [[INBANDTRACKS]], then
             it SHOULD try to use the same attribute mappings so that Media Source Extensions playback and non-Media Source Extensions playback provide the

--- a/media-source.js
+++ b/media-source.js
@@ -596,31 +596,6 @@
       }
     }
  
-    // Work around ReSpec issue 893
-    $("a[href='#dom-readystate']").each( function() {
-    
-        var $ant = $(this);
-        if ( $ant.text() === "ReadyState" ) {
-            console.log("ReSpec#893: Fixing incorrect link for ReadyState");
-            
-            $ant.attr({href:"#idl-def-readystate"});
-        }
-    
-    });
- 
-    $("span.idlAttrName").each(function() {
-    
-        var $ant = $(this);
-        if ( $ant.text() == "readyState" ) {
-            console.log("ReSpec#893: Fixing link for readyState IDL attribute");
-            
-            $ant.empty();
-            $ant.append($('<a href="#dom-readystate"><code>readyState</code></a>'));
-        }
-    
-    });
-    // End workaround for ReSpec issue 893
- 
     $("a[href]").each(function () {
       var link = $(this);
       var href = link.attr('href');


### PR DESCRIPTION
This update makes a (somewhat) minimal set of changes to have the Status of this Document section say that the document is governed by Process 2020.

In theory, that should be as simple as switching to the right profile of ReSpec. In practice, that version of ReSpec changed a few things on the way definitions are handled, requiring a few other updates to definitions and links for ReSpec not to get linking errors and warnings from ReSpec.

One of these updates is using the right shorthand to link back occurrences of `readyState` (the attribute) and `ReadyState` (the enum). ReSpec now supports case sensitivity for IDL terms, and the workaround implemented in `media-source.js` was not perfect in any case (in the published Rec, an instance of "ReadyState" links back to the attribute definition in the IDL block instead of to the definition of the enum).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/media-source/pull/263.html" title="Last updated on Nov 24, 2020, 7:01 PM UTC (936dc7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/263/082c42b...tidoust:936dc7a.html" title="Last updated on Nov 24, 2020, 7:01 PM UTC (936dc7a)">Diff</a>