### PR TITLE
Upstream codec switching (changeType) feature from WICG incubation spec

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -1491,8 +1491,8 @@ interface SourceBuffer : EventTarget {
                     (a) the most recently successful {{SourceBuffer/changeType()}} on this {{SourceBuffer}} object, or
                     (b) if no successful {{SourceBuffer/changeType()}} has yet occurred on this object, the {{MediaSource/addSourceBuffer()}}
                     that created this {{SourceBuffer}} object.
-                    For example, MediaSource.isTypeSupported('video/webm;codecs="vp8,vorbis"') may return true, but if
-                    {{MediaSource/addSourceBuffer()}} was called with 'video/webm;codecs="vp8"' and a Vorbis track appears in the
+                    For example, <code>MediaSource.isTypeSupported('video/webm;codecs="vp8,vorbis"')</code> may return true, but if
+                    {{MediaSource/addSourceBuffer()}} was called with <code>'video/webm;codecs="vp8"'</code> and a Vorbis track appears in the
                     [=initialization segment=], then the user agent MAY use this step to trigger a decode error.
                     Implementations are encouraged to trigger error in such cases only when the codec is indeed not supported.
                     Web authors are encouraged to use {{SourceBuffer/changeType()}}, {{MediaSource/addSourceBuffer()}} and

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -1464,7 +1464,7 @@ interface SourceBuffer : EventTarget {
                         (b) if no successful {{SourceBuffer/changeType()}} has yet occurred on this object, the {{MediaSource/addSourceBuffer()}}
                         that created this {{SourceBuffer}} object.
                         For example, if the most recently successful {{SourceBuffer/changeType()}} was called with <code>'video/webm'</code>
-                        or 'video/webm; codecs="vp8"', and a video track containing vp9 appears in the initialization segment,
+                        or <code>'video/webm; codecs="vp8"'</code>, and a video track containing vp9 appears in the initialization segment,
                         then the user agent MAY use this step to trigger a decode error even if the other two properties'
                         checks, above, pass. Implementations are encouraged to trigger error in such cases only when the codec
                         is indeed not supported or the other two properties' checks fail.

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -2252,7 +2252,6 @@ interface SourceBufferList : EventTarget {
       <h2><dfn data-export="">Byte Stream Formats</dfn></h2>
       <p>The bytes provided through {{SourceBuffer/appendBuffer()}} for a <a>SourceBuffer</a> form a logical byte stream. The format and
         semantics of these byte streams are defined in <dfn id="byte-stream-format-specs">byte stream format specifications</dfn>.
-        <!-- BIG TODO: verify the following paragraph text is good -->
         The byte stream format registry [[MSE-REGISTRY]] provides mappings between a MIME type that may be passed to {{MediaSource/addSourceBuffer()}},
         {{MediaSource/isTypeSupported()}} or {{SourceBuffer/changeType()}} and the byte stream format expected by a {{SourceBuffer}} using that
         MIME type for parsing newly appended data. Implementations are encouraged to register
@@ -2280,7 +2279,6 @@ interface SourceBufferList : EventTarget {
               <p class="note">For example, if the first [=initialization segment=] has 2 audio tracks and 1 video track, then all [=initialization segments=] that follow it in the byte stream MUST describe 2 audio tracks and 1 video track.</p>
             </li>
             <li>[=Track IDs=] are not the same across [=initialization segments=], for segments describing multiple tracks of a single type (e.g., 2 audio tracks).</li>
-            <li><!-- BIG TODO verify this is good -->
               <p>Unsupported codec changes occur across across [=initialization segments=].</p>
               <p class="note">See the [=initialization segment received=] algorithm, {{MediaSource/addSourceBuffer()}} and {{SourceBuffer/changeType()}} for details and examples of codec changes.</p>
             </li>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -2279,6 +2279,7 @@ interface SourceBufferList : EventTarget {
               <p class="note">For example, if the first [=initialization segment=] has 2 audio tracks and 1 video track, then all [=initialization segments=] that follow it in the byte stream MUST describe 2 audio tracks and 1 video track.</p>
             </li>
             <li>[=Track IDs=] are not the same across [=initialization segments=], for segments describing multiple tracks of a single type (e.g., 2 audio tracks).</li>
+            <li>
               <p>Unsupported codec changes occur across across [=initialization segments=].</p>
               <p class="note">See the [=initialization segment received=] algorithm, {{MediaSource/addSourceBuffer()}} and {{SourceBuffer/changeType()}} for details and examples of codec changes.</p>
             </li>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -932,7 +932,7 @@ interface SourceBuffer : EventTarget {
     undefined changeType (DOMString type);
     undefined remove (double start, unrestricted double end);
 };</pre><section><h2>Attributes</h2><dl class="attributes" data-dfn-for="SourceBuffer"><dt><dfn><code>mode</code></dfn> of type <a>AppendMode</a></dt><dd>
-<p>Controls how a sequence of [=media segments=] are handled. This attribute is initially set by {{MediaSource/addSourceBuffer()}} after the object is created, and can be updated by {{SourceBuffer/changeType}} or setting this attribute.</p>
+<p>Controls how a sequence of [=media segments=] are handled. This attribute is initially set by {{MediaSource/addSourceBuffer()}} after the object is created, and can be updated by {{SourceBuffer/changeType()}} or setting this attribute.</p>
           <p>On getting, Return the initial value or the last value that was successfully set.</p>
           <p>On setting, run the following steps:</p>
           <ol>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -1463,7 +1463,7 @@ interface SourceBuffer : EventTarget {
                         (a) the most recently successful {{SourceBuffer/changeType()}} on this {{SourceBuffer}} object, or
                         (b) if no successful {{SourceBuffer/changeType()}} has yet occurred on this object, the {{MediaSource/addSourceBuffer()}}
                         that created this {{SourceBuffer}} object.
-                        For example, if the most recently successful {{SourceBuffer/changeType()}} was called with 'video/webm'
+                        For example, if the most recently successful {{SourceBuffer/changeType()}} was called with <code>'video/webm'</code>
                         or 'video/webm; codecs="vp8"', and a video track containing vp9 appears in the initialization segment,
                         then the user agent MAY use this step to trigger a decode error even if the other two properties'
                         checks, above, pass. Implementations are encouraged to trigger error in such cases only when the codec

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -2280,7 +2280,7 @@ interface SourceBufferList : EventTarget {
             </li>
             <li>[=Track IDs=] are not the same across [=initialization segments=], for segments describing multiple tracks of a single type (e.g., 2 audio tracks).</li>
             <li>
-              <p>Unsupported codec changes occur across across [=initialization segments=].</p>
+              <p>Unsupported codec changes occur across [=initialization segments=].</p>
               <p class="note">See the [=initialization segment received=] algorithm, {{MediaSource/addSourceBuffer()}} and {{SourceBuffer/changeType()}} for details and examples of codec changes.</p>
             </li>
           </ol>


### PR DESCRIPTION
Merges remote-tracking branch 'wicg-upstream/codec-switching'
Pulls in the incubated codec-switching, aka changeType, specification
from WICG fork. Strips out incubation boilerplate and unrelated pieces
from the downstream codec-switching branch, and updates to the recently
applied respec shorthand in upstream. The net result is that only
media-source-respec.html is updated.
Multiple user agents have shipped this feature already, and web-platform
tests already exist for it. See w3c/mediasource/issues/155 (#155).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wolenetz/media-source/pull/274.html" title="Last updated on May 18, 2021, 6:35 PM UTC (ff03151)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/274/9f44440...wolenetz:ff03151.html" title="Last updated on May 18, 2021, 6:35 PM UTC (ff03151)">Diff</a>