### PR TITLE
"abort" event description no longer includes "remove"

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -1457,7 +1457,7 @@ interface SourceBuffer : EventTarget {
             <tr>
               <td><dfn><code>abort</code></dfn></td>
               <td><code>Event</code></td>
-              <td>The append or remove was aborted by an {{SourceBuffer/abort()}} call. {{SourceBuffer/updating}} transitions from true to false.</td>
+              <td>The append was aborted by an {{SourceBuffer/abort()}} call. {{SourceBuffer/updating}} transitions from true to false.</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
Fixes #287


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wolenetz/media-source/pull/293.html" title="Last updated on Sep 1, 2021, 6:21 PM UTC (e4e5b93)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/293/6efee8e...wolenetz:e4e5b93.html" title="Last updated on Sep 1, 2021, 6:21 PM UTC (e4e5b93)">Diff</a>