### PR TITLE
Move abstract back to first section in the spec

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -122,19 +122,18 @@
     <link rel="stylesheet" href="mse.css">
   </head>
   <body data-cite="html dom url">
+    <section id="abstract">
+      This specification extends {{HTMLMediaElement}} [[HTML]] to allow
+      JavaScript to generate media streams for playback.
+      Allowing JavaScript to generate streams facilitates a variety of use
+      cases like adaptive streaming and time shifting live streams.
+    </section>
 
     <section id="sotd">
       <p>On top of editorial updates, substantives changes since publication as a W3C Recommendation in <a href="https://www.w3.org/TR/2016/REC-media-source-20161117/">November 2016</a> are the addition of a {{SourceBuffer/changeType()}} method to switch codecs, the possibility to create and use {{MediaSource}} objects off the main thread in dedicated workers, and the removal of the <code>createObjectURL()</code> extension to the {{URL}} object following its integration in the File API [[FILEAPI]]. For a full list of changes done since the previous version, see the <a href="https://github.com/w3c/media-source/commits/main">commits</a>.</p>
 
       <p>The working group maintains <a href="https://github.com/w3c/media-source/issues">a list of all bug reports that the editors have not yet tried to address</a>.</p>
       <p>Implementors should be aware that this specification is not stable. <strong>Implementors who are not taking part in the discussions are likely to find the specification changing out from under them in incompatible ways.</strong> Vendors interested in implementing this specification before it eventually reaches the Candidate Recommendation stage should track the <a href="https://github.com/w3c/media-source">GitHub repository</a> and take part in the discussions.</p>
-    </section>
-
-    <section id="abstract">
-      This specification extends {{HTMLMediaElement}} [[HTML]] to allow
-      JavaScript to generate media streams for playback.
-      Allowing JavaScript to generate streams facilitates a variety of use
-      cases like adaptive streaming and time shifting live streams.
     </section>
 
     <section id="introduction" class="informative">


### PR DESCRIPTION
The Status of This Document section must follow the abstract per pubrules, not precedes it.
(Update needed for publication as FPWD)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/pull/298.html" title="Last updated on Sep 23, 2021, 8:34 AM UTC (21c4614)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/298/8842ce9...21c4614.html" title="Last updated on Sep 23, 2021, 8:34 AM UTC (21c4614)">Diff</a>