### PR TITLE
Automate publication to /TR and handle static files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,48 @@
 name: CI
 on:
+  # Worflow runs on pull requests where it makes sure that the spec can be
+  # generated, that markup and IDL are valid, as well as on pushes to the
+  # default branch where it also deploys the generated spec to the gh-pages
+  # branch and publishes the result to /TR.
+  # The "workflow_dispatch" hook allows repo admins to trigger the workflow
+  # manually if needed.
   pull_request: {}
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   main:
     name: Build, Validate and Deploy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: w3c/spec-prod@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # If event is a push to main branch (and not a pull request),
+      # copy static files over to the gh-pages branch, excluding files
+      # that don't need to be published, and preserving older versions
+      # of the spec that are in the gh-pages branch.
+      - name: Deploy static files
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: peaceiris/actions-gh-pages@v3.8.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./
+          exclude_assets: '.github,*.md,*.json,media-source-respec.html'
+          keep_files: true
+
+      # Run spec-prod action to build, validate the spec itself and,
+      # if event is a push, deploy it both to the gh-pages branch and
+      # to w3.org/TR
+      - name: Build, validate and deploy spec
+        uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: respec
           SOURCE: media-source-respec.html
           DESTINATION: index.html
           GH_PAGES_BRANCH: gh-pages
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://github.com/w3c/media-wg/issues/27
+          W3C_BUILD_OVERRIDE: |
+            status: WD


### PR DESCRIPTION
This update completes the job that validates and publishes the spec to handle static files as well (images, companion documents, MSE v1 errata) and to now publish Working Draft updates automatically to /TR.

The `ECHIDNA_TOKEN` secret was added to the repo settings.