### PR TITLE
Editorial: Use absolute URL for process flowchart description

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -136,7 +136,7 @@
     <section id="introduction" class="informative">
       <h2>Introduction</h2>
       <p>This specification allows JavaScript to dynamically construct media streams for &lt;audio&gt; and &lt;video&gt;. It defines a MediaSource object that can serve as a source of media data for an HTMLMediaElement. MediaSource objects have one or more <a>SourceBuffer</a> objects.  Applications append data segments to the <a>SourceBuffer</a> objects, and can adapt the quality of appended data based on system performance and other factors. Data from the <a>SourceBuffer</a> objects is managed as track buffers for audio, video and text data that is decoded and played. Byte stream specifications used with these extensions are available in the byte stream format registry [[MSE-REGISTRY]].</p>
-      <a href='pipeline_model_description.html#pipelinedesc'>
+      <a href='https://w3c.github.io/media-source/pipeline_model_description.html#pipelinedesc'>
         <picture><img src="pipeline_model.svg" alt="Media Source Pipeline Model Diagram"></picture>
       </a>
       <section id="goals">


### PR DESCRIPTION
Raised in §1 in https://github.com/w3c/media-source/issues/307

The automatic publication system does not currently support publications of additional HTML files to /TR, so the description document is not available from https://www.w3.org/TR/media-source-2/

Solution for now is to target the version on GitHub Pages in Working Drafts, and to manually publish the description document for "snapshot" publication statuses (FPWD, CR, PR, REC).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/media-source/pull/308.html" title="Last updated on Apr 27, 2022, 8:51 AM UTC (10c9554)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/308/89bd50e...tidoust:10c9554.html" title="Last updated on Apr 27, 2022, 8:51 AM UTC (10c9554)">Diff</a>