### PR TITLE
Improve pipeline model text description clarity

### DIFF
--- a/pipeline_model_description.html
+++ b/pipeline_model_description.html
@@ -31,7 +31,6 @@ HTMLMediaElement.<p>
 
 
 
-
 <h3 id='sourcebuffer1'>Flowing down from SourceBuffer 1</h3>
 
 
@@ -46,11 +45,10 @@ labeled Video Tag Display Region.</p>
 then follows to an indicator of an open switch, which then continues to an
 indicator (green circle with an X) labeled Audio Device.</p>
 
-<p>The third Track Buffer also flows to a green box labeled Video Decoder,
+<p>The third Track Buffer also flows to a green box labeled Audio Decoder,
 which also flows to a switch, this time however indicated closed, which then
 also continues to the same indicator (green circle with an X) labeled Audio
 Device as the second Track Buffer.</p>
-
 
 
 
@@ -58,17 +56,24 @@ Device as the second Track Buffer.</p>
 
 
 <p>Flowing down from SourceBuffer 2 is a mauve triangle with an arrow flowing
-to a red box labeled Video Decoder, which then flows to the same  Video Tag
-Display Region previously mentioned in SourceBuffer 1.</p>
+to a process indication labeled Track Buffer.<p>
+
+<p>This Track Buffer then flows to a red box labeled Video Decoder, which
+then flows to the same Video Tag Display Region previously mentioned in
+SourceBuffer 1.</p>
+
 
 
 <h3 id='sourcebuffer3'>Flowing down from SourceBuffer 3</h3>
 
 
 <p>Flowing down from SourceBuffer 3 is a rose triangle with an arrow flowing to
-a green box labeled Audio Decoder, which then flows through a closed switch,
-which then also continues to the same indicator (green circle with an X)
-labeled Audio Device previously mentioned in SourceBuffer 1</p>
+a process indication labeled Track Buffer.<p>
+
+<p>This Track Buffer then flows to a green box labeled Audio Decoder, which
+then flows through a closed switch, which then also continues to the same
+indicator (green circle with an X) labeled Audio Device previously mentioned in
+SourceBuffer 1</p>
 
 
 <p style='text-align: right;'>With thanks to <a href='https://lists.w3.org/Archives/Public/public-apa/2016Jan/0014.html'>J. Foliot, Deque Systems</a></p>


### PR DESCRIPTION
Fixes a typo (one of the flows was described incorrectly as going to a
Video Decoder, not an Audio Decoder), and fixes a couple omissions of
mentions of track buffer process indications between SourceBuffer 2
and Video Decoder, and between SourceBuffer 3 and Audio Decoder.

(I found these issues while investigating #307 and reviewing #308.)