### PR TITLE
Use "summing junction" in pipeline model description

### DIFF
--- a/pipeline_model_description.html
+++ b/pipeline_model_description.html
@@ -17,64 +17,57 @@
 <h2 id='pipelinedesc'>Non-technical description of the Process Flowchart image</h2>
 
     <p>The flowchart reads from a top down perspective. At the top is a container
-marked MediaSource, with 3 arrows flowing down to containers each marked
+marked MediaSource, with three arrows flowing down to containers each marked
 SourceBuffer. (Not indicated, but for sake of clarity in this description
 referred to here-after as SourceBuffer 1, shown with a blue background;
 SourceBuffer 2, shown with a mauve background; and SourceBuffer 3, shown
 with a rose background; as described from Left to Right).</p>
 
-
-<p>Below these 3 SourceBuffer containers is a dashed line, with an indication
-that the top half (MediaSource plus the 3 SourceBuffer containers) are taken
+<p>Below these three SourceBuffer containers is a dashed line, with an indication
+that the top half (MediaSource plus the three SourceBuffer containers) are taken
 from the Media Source API, while the details to follow are taken from the
 HTMLMediaElement.<p>
 
-
-
 <h3 id='sourcebuffer1'>Flowing down from SourceBuffer 1</h3>
 
-
-<p>Flowing down from SourceBuffer 1 is a blue triangle with 3 arrows pointing
-to 3 process indications, each labeled Track Buffer.</p>
+<p>Flowing down from SourceBuffer 1 is a blue triangle with three arrows pointing
+to three process indications, each labeled Track Buffer.</p>
 
 <p>The first Track Buffer from the left then flows to a red box labeled Video
-Decoder, which then flows to an indicator (three dots stacked vertically)
-labeled Video Tag Display Region.</p>
+Decoder, which then flows to a switch that selects between one of three inputs,
+and the output of the switch connects to an output destination, labeled Video Tag
+Display Region. The switch indicates that one Video Decoder output (from
+SourceBuffer 2) is selected to flow into the Video Tag Display Region.</p>
 
 <p>The second Track Buffer flows to a green box labeled Audio Decoder, which
-then follows to an indicator of an open switch, which then continues to an
-indicator (green circle with an X) labeled Audio Device.</p>
+then follows to an indicator of an open switch, which then continues to a
+summing junction indicator. The output of the summing junction connects to
+a green output desination, labeled Audio Device.</p>
 
 <p>The third Track Buffer also flows to a green box labeled Audio Decoder,
 which also flows to a switch, this time however indicated closed, which then
-also continues to the same indicator (green circle with an X) labeled Audio
-Device as the second Track Buffer.</p>
-
-
+also continues to the same summing junction as the second Track Buffer,
+which connects to the Audio Device.</p>
 
 <h3 id='sourcebuffer2'>Flowing down from SourceBuffer 2</h3>
-
 
 <p>Flowing down from SourceBuffer 2 is a mauve triangle with an arrow flowing
 to a process indication labeled Track Buffer.<p>
 
 <p>This Track Buffer then flows to a red box labeled Video Decoder, which
-then flows to the same Video Tag Display Region previously mentioned in
-SourceBuffer 1.</p>
-
-
+then flows to the same switch that feeds to the Video Tag Display Region
+previously mentioned in SourceBuffer 1. The switch is positioned so that
+this Video Decoder ouptut is connected to the Video Tag Display Region.</p>
 
 <h3 id='sourcebuffer3'>Flowing down from SourceBuffer 3</h3>
-
 
 <p>Flowing down from SourceBuffer 3 is a rose triangle with an arrow flowing to
 a process indication labeled Track Buffer.<p>
 
 <p>This Track Buffer then flows to a green box labeled Audio Decoder, which
 then flows through a closed switch, which then also continues to the same
-indicator (green circle with an X) labeled Audio Device previously mentioned in
-SourceBuffer 1</p>
-
+summing junction previously mentioned in SourceBuffer 1, which connects to the
+Audio Device.</p>
 
 <p style='text-align: right;'>With thanks to <a href='https://lists.w3.org/Archives/Public/public-apa/2016Jan/0014.html'>J. Foliot, Deque Systems</a></p>
 


### PR DESCRIPTION
See #314 and https://github.com/w3c/media-source/pull/310#pullrequestreview-977668328.  This PR changes the description of the pipeline model diagram to describe the Audio Decoder outputs flowing into a summing junction, which outputs to the Audio Device. It also includes other editorial changes to further clarify the description, such as describing the video output selection as a switch.