### PR TITLE
Change MediaSource handle getter value to null from exception

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -322,7 +322,7 @@
 <pre class="idl">[Exposed=(Window,DedicatedWorker)]
 interface MediaSource : EventTarget {
     constructor();
-    [SameObject] readonly attribute MediaSourceHandle   handle;
+    [SameObject] readonly attribute MediaSourceHandle?  handle;
     readonly              attribute SourceBufferList    sourceBuffers;
     readonly              attribute SourceBufferList    activeSourceBuffers;
     readonly              attribute ReadyState          readyState;
@@ -342,18 +342,18 @@ interface MediaSource : EventTarget {
         <h3>Attributes</h3>
         <dl class="attributes" data-dfn-for="MediaSource">
 
-          <dt><dfn><code>handle</code></dfn> of type <span class="idlAttrType"><a>MediaSourceHandle</a></span>, [SameObject] readonly</dt><dd>
+          <dt><dfn><code>handle</code></dfn> of type <span class="idlAttrType"><a>MediaSourceHandle</a></span>, [SameObject] readonly nullable</dt><dd>
 
           <p>Contains a handle useful for attachment to an {{HTMLMediaElement}} via {{HTMLMediaElement/srcObject}}.
           The handle remains the same object for this {{MediaSource}} object across accesses of this attribute, but it
           is distinct for each {{MediaSource}} object.</p>
           <p>On getting, run the following steps:</p>
           <ol>
-            <li>If the implementation does not support creating a handle for this {{MediaSource}}, then throw a
-              {{NotSupportedError}} exception and abort these steps.
-              <p class="note">Implementations MAY choose to only allow handle creation for {{MediaSource}} objects in a
-                {{DedicatedWorkerGlobalScope}}, as a minimum requirement for enabling attachment of such a {{MediaSource}}
-                object to an {{HTMLMediaElement}}.</p>
+            <li>If the implementation does not support creating a handle for this {{MediaSource}}, then let the
+              attribute value be null and return null without running any further steps.
+              <p class="note">This attribute's value must remain the same across accesses. Implementations MAY choose to
+              only allow handle creation for {{MediaSource}} objects in a {{DedicatedWorkerGlobalScope}}, as a minimum
+              requirement for enabling attachment of such a {{MediaSource}} object to an {{HTMLMediaElement}}.</p>
             </li>
             <li>If the handle for this {{MediaSource}} object has not yet been created, then run the following steps:
               <ol>


### PR DESCRIPTION
Due to compatibility issues with existing web app libraries that enumerate MediaSource attributes, throwing an exception on attempted read of a MediaSource object's handle attribute was unfortunately a breaking change.

This change updates the spec to instead make the MediaSource handle attribute readonly [SameObject] getter return null instead of throwing an exception if the implementation doesn't support creating a MediaSourceHandle for that MediaSource object instance.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wolenetz/media-source/pull/316.html" title="Last updated on Sep 8, 2022, 10:18 PM UTC (5e74cf9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/316/099830e...wolenetz:5e74cf9.html" title="Last updated on Sep 8, 2022, 10:18 PM UTC (5e74cf9)">Diff</a>