### PR TITLE
Restrict handle getter visibility to dedicated worker

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -322,7 +322,10 @@
 <pre class="idl">[Exposed=(Window,DedicatedWorker)]
 interface MediaSource : EventTarget {
     constructor();
-    [SameObject] readonly attribute MediaSourceHandle   handle;
+
+    [ SameObject, Exposed=DedicatedWorker ]
+    readonly              attribute MediaSourceHandle   handle;
+
     readonly              attribute SourceBufferList    sourceBuffers;
     readonly              attribute SourceBufferList    activeSourceBuffers;
     readonly              attribute ReadyState          readyState;
@@ -344,22 +347,22 @@ interface MediaSource : EventTarget {
 
           <dt><dfn><code>handle</code></dfn> of type <span class="idlAttrType"><a>MediaSourceHandle</a></span>, [SameObject] readonly</dt><dd>
 
-          <p>Contains a handle useful for attachment to an {{HTMLMediaElement}} via {{HTMLMediaElement/srcObject}}.
-          The handle remains the same object for this {{MediaSource}} object across accesses of this attribute, but it
-          is distinct for each {{MediaSource}} object.</p>
+          <p>Contains a handle useful for attachment of a dedicated worker {{MediaSource}} object to an
+          {{HTMLMediaElement}} via {{HTMLMediaElement/srcObject}}. The handle remains the same object for this
+          {{MediaSource}} object across accesses of this attribute, but it is distinct for each {{MediaSource}}
+          object.</p>
+
+          <p class="note">This specification may eventually enable visibility of this attribute on {{MediaSource}}
+          objects on the main Window context. If so, specification care will be necessary to prevent potential backwards
+          incompatible changes, such as could happen if exceptions were thrown on accesses to this attribute.</p>
+
           <p>On getting, run the following steps:</p>
           <ol>
-            <li>If the implementation does not support creating a handle for this {{MediaSource}}, then throw a
-              {{NotSupportedError}} exception and abort these steps.
-              <p class="note">Implementations MAY choose to only allow handle creation for {{MediaSource}} objects in a
-                {{DedicatedWorkerGlobalScope}}, as a minimum requirement for enabling attachment of such a {{MediaSource}}
-                object to an {{HTMLMediaElement}}.</p>
             </li>
             <li>If the handle for this {{MediaSource}} object has not yet been created, then run the following steps:
               <ol>
-                <li>Let |created handle:MediaSourceHandle| be the result of creating a new
-              {{MediaSourceHandle}} object and associated resources, linked internally to this
-              {{MediaSource}}.</li>
+                <li>Let |created handle:MediaSourceHandle| be the result of creating a new {{MediaSourceHandle}} object
+                  and associated resources, linked internally to this {{MediaSource}}.</li>
                 <li>Update the attribute to be |created handle|.</li>
               </ol>
             <li>Return the {{MediaSourceHandle}} object that is this attribute's value.</li>


### PR DESCRIPTION
Removes the MediaSource handle attribute visibility from the main Window context, leaving it visible only in dedicated worker contexts. Also removes the conditional throwing of NotSupportedError exceptions on getting this attribute's value if the implementation doesn't support that.

Overall, this change is to undo the backwards incompatibility issue found when older versions of MSE web app libraries enumerated main thread MediaSource attribute values, hitting exception in the Chromium feature implementation through milestone 107. This change replaces that with simpler and safer visibility restriction of this getter to just the context where it must be supported if the implementation supports MSE-in-Workers.

Note, this change replaces the alternative fix discussed in w3c/media-source PR #316.

Reference feature tracking spec issue for MSE-in-Workers w3c/media-source issue #175.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wolenetz/media-source/pull/317.html" title="Last updated on Sep 20, 2022, 8:18 PM UTC (84755e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/317/099830e...wolenetz:84755e5.html" title="Last updated on Sep 20, 2022, 8:18 PM UTC (84755e5)">Diff</a>