### PR TITLE
Editorial: switch MediaSource to using headings

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -275,9 +275,9 @@
       </section>
     </section>
 
-    <section id="mediasource">
-      <h2><dfn>MediaSource</dfn> Object</h2>
-      <p>The MediaSource object represents a source of media data for an HTMLMediaElement. It keeps track of the {{MediaSource/readyState}} for this source as well as a list of <a>SourceBuffer</a> objects that can be used to add media data to the presentation. MediaSource objects are created by the web application and then attached to an HTMLMediaElement. The application uses the <a>SourceBuffer</a> objects in {{MediaSource/sourceBuffers}} to add media data to this source. The HTMLMediaElement fetches this media data from the <a>MediaSource</a> object when it is needed during playback.</p>
+    <section id="mediasource" data-dfn-for="MediaSource">
+      <h2><dfn>MediaSource</dfn> interface</h2>
+      <p>The {{MediaSource}} interface represents a source of media data for an {{HTMLMediaElement}}. It keeps track of the {{MediaSource/readyState}} for this source as well as a list of <a>SourceBuffer</a> objects that can be used to add media data to the presentation. MediaSource objects are created by the web application and then attached to an HTMLMediaElement. The application uses the <a>SourceBuffer</a> objects in {{MediaSource/sourceBuffers}} to add media data to this source. The HTMLMediaElement fetches this media data from the <a>MediaSource</a> object when it is needed during playback.</p>
 
       <p>Each {{MediaSource}} object has a <dfn data-dfn-for="MediaSource">[[\live seekable range]]</dfn> internal slot
         that stores a <a def-id="normalized-timeranges-object"></a>. It is initialized to an empty {{TimeRanges}} object
@@ -344,11 +344,8 @@ interface MediaSource : EventTarget {
     undefined             clearLiveSeekableRange ();
     static boolean        isTypeSupported (DOMString type);
 };</pre>
-      <section>
-        <h3>Attributes</h3>
-        <dl class="attributes" data-dfn-for="MediaSource">
 
-          <dt><dfn><code>handle</code></dfn> of type <span class="idlAttrType"><a>MediaSourceHandle</a></span>, [SameObject] readonly</dt><dd>
+          <h3><dfn><code>handle</code></dfn> attribute</h3>
 
           <p>Contains a handle useful for attachment of a dedicated worker {{MediaSource}} object to an
           {{HTMLMediaElement}} via {{HTMLMediaElement/srcObject}}. The handle remains the same object for this
@@ -371,9 +368,12 @@ interface MediaSource : EventTarget {
             <li>Return the {{MediaSourceHandle}} object that is this attribute's value.</li>
           </ol>
 
-          <dt><dfn><code>sourceBuffers</code></dfn> of type <span class="idlAttrType"><a>SourceBufferList</a></span>, readonly       </dt><dd>
-          Contains the list of <a>SourceBuffer</a> objects associated with this <a>MediaSource</a>. When {{MediaSource/readyState}} equals {{ReadyState/""closed""}} this list will be empty. Once {{MediaSource/readyState}} transitions to {{ReadyState/""open""}} SourceBuffer objects can be added to this list by using {{MediaSource/addSourceBuffer()}}.
-        </dd><dt><dfn><code>activeSourceBuffers</code></dfn> of type <span class="idlAttrType"><a>SourceBufferList</a></span>, readonly       </dt><dd>
+          <h3><dfn>sourceBuffers</dfn> attribute</h3>
+          <p>
+          Contains the list of {{SourceBuffer}} objects associated with this {{MediaSource}}. When {{MediaSource}}'s {{MediaSource/readyState}} equals {{ReadyState/""closed""}} this list will be empty. Once {{MediaSource/readyState}} transitions to {{ReadyState/""open""}} SourceBuffer objects can be added to this list by using {{MediaSource/addSourceBuffer()}}.
+          </p>
+
+          <h3><dfn>activeSourceBuffers</dfn> attribute</h3>
           <p>Contains the subset of {{MediaSource/sourceBuffers}} that are providing the {{VideoTrack/selected}} video track, the
             {{AudioTrack/enabled}} audio track(s), and the
             <a def-id="texttrackmode-showing"></a> or <a def-id="texttrackmode-hidden"></a> text track(s).
@@ -385,9 +385,11 @@ interface MediaSource : EventTarget {
           </p>
           <p class="note">The <a href="#active-source-buffer-changes">Changes to selected/enabled track state</a> section describes how this attribute gets
             updated.</p>
-        </dd><dt><dfn><code>readyState</code></dfn> of type {{ReadyState}}, readonly       </dt><dd>
+
+         <h3><dfn>readyState</dfn> attribute</h3>
           <p>Indicates the current state of the <a>MediaSource</a> object. When the <a>MediaSource</a> is created {{MediaSource/readyState}} MUST be set to {{ReadyState/""closed""}}.
-        </p></dd><dt><dfn><code>duration</code></dfn> of type {{unrestricted double}}</dt><dd>
+        </p>
+        <h3><dfn>duration</dfn> attribute</h3>
           <p>Allows the web application to set the presentation duration. The duration is initially set to NaN when the <a>MediaSource</a> object is created.</p>
           <p>On getting, run the following steps:</p>
           <ol>
@@ -404,22 +406,18 @@ interface MediaSource : EventTarget {
               <p class="note">{{SourceBuffer/appendBuffer()}} and {{MediaSource/endOfStream()}} can update the duration under certain circumstances.</p>
             </li>
           </ol>
-        </dd><dt><dfn><code>onsourceopen</code></dfn> of type {{EventHandler}}</dt><dd>
-          <p>The event handler for the {{sourceopen}} event.</p>
-        </dd><dt><dfn><code>onsourceended</code></dfn> of type {{EventHandler}}</dt><dd>
-          <p>The event handler for the {{sourceended}} event.</p>
-        </dd><dt><dfn><code>onsourceclose</code></dfn> of type {{EventHandler}}</dt><dd>
-          <p>The event handler for the {{sourceclose}} event.</p>
-        </dd>
-        <dt><dfn><code>canConstructInDedicatedWorker</code></dfn> of type {{boolean}}</dt><dd>
+
+        <h3><dfn>canConstructInDedicatedWorker</dfn> attribute</h3>
           <p>Returns true.</p>
           <p class="note">This attribute enables main thread and dedicated worker feature detection of support for
             creating and using a {{MediaSource}} object in a dedicated worker, and mitigates the need for higher latency
             detection polyfills like attempting creation of a {{MediaSource}} object from a dedicated worker, especially
             if the feature is not supported.</p>
-        </dd></dl></section><section><h2>Methods</h2><dl class="methods" data-dfn-for="MediaSource"><dt><dfn><code>addSourceBuffer</code></dfn></dt><dd>
+
+
+        <h3><dfn>addSourceBuffer()</dfn> method</h3>
           <p>Adds a new <a>SourceBuffer</a> to {{MediaSource/sourceBuffers}}.</p>
-          <ol class="method-algorithm">
+          <ol class="algorithm">
             <li>If |type:DOMString| is an empty string then throw a {{TypeError}} exception and abort these steps.</li>
             <li>If |type| contains a MIME type that is not supported or contains a MIME type that is not supported with the types specified for the other <a>SourceBuffer</a> objects in {{MediaSource/sourceBuffers}}, then throw a {{NotSupportedError}} exception and abort these steps.</li>
             <li>If the user agent can't handle any more SourceBuffer objects or if creating a SourceBuffer
@@ -454,10 +452,10 @@ interface MediaSource : EventTarget {
           </ol>
         <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><th class="prmName">|type|</th><td class="prmType">{{DOMString}}</td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em><a>SourceBuffer</a></div></dd>
 
-          <dt><dfn><code>removeSourceBuffer</code></dfn></dt><dd>
+          <h3><dfn>removeSourceBuffer()</dfn> method</h3>
           <p>Removes a {{SourceBuffer}} from {{MediaSource/sourceBuffers}}.</p>
 
-          <ol class="method-algorithm">
+          <ol class="algorithm">
             <li>If |sourceBuffer:SourceBuffer| specifies an object that is not in {{MediaSource/sourceBuffers}} then throw a {{NotFoundError}} exception and abort these steps.</li>
             <li>If the |sourceBuffer|.{{SourceBuffer/updating}} attribute equals true, then run the following steps:
               <ol>
@@ -614,10 +612,10 @@ interface MediaSource : EventTarget {
         <table
           class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><th class="prmName">|sourceBuffer|</th><td class="prmType">{{SourceBuffer}}</td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em>{{undefined}}</div></dd>
 
-          <dt><dfn><code>endOfStream</code></dfn></dt><dd>
+        <h3><dfn>endOfStream()</dfn> method</h3>
           <p>Signals the end of the stream.</p>
 
-          <ol class="method-algorithm">
+          <ol class="algorithm">
             <li>If the {{MediaSource/readyState}} attribute is not in the {{ReadyState/""open""}} state then throw an {{InvalidStateError}} exception and abort these steps.</li>
             <li>If the {{SourceBuffer/updating}} attribute equals true on any <a>SourceBuffer</a> in {{MediaSource/sourceBuffers}}, then throw an {{InvalidStateError}} exception and abort these steps.</li>
             <li>Run the [=end of stream=] algorithm with the error parameter set to |error:EndOfStreamError|.</li>
@@ -625,12 +623,12 @@ interface MediaSource : EventTarget {
         <table
           class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><th class="prmName">|error|</th><td class="prmType">{{EndOfStreamError}}</td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptTrue"><span role="img" aria-label="True">✔</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em>{{undefined}}</div></dd>
 
-          <dt><dfn><code>setLiveSeekableRange</code></dfn></dt><dd>
+          <h3><dfn>setLiveSeekableRange()</dfn> method</h3>
 
           <p>Updates {{MediaSource/[[live seekable range]]}} that is used in
             <a href="#htmlmediaelement-extensions">HTMLMediaElement Extensions</a> to modify
             {{HTMLMediaElement}}.{{HTMLMediaElement/seekable}} behavior.</p>
-          <ol class="method-algorithm">
+          <ol class="algorithm">
             <li>If the {{MediaSource/readyState}} attribute is not {{ReadyState/""open""}} then throw an {{InvalidStateError}} exception and abort these steps.</li>
             <li>If |start:double| is negative or greater than |end:double|, then throw a {{TypeError}} exception and abort these steps.</li>
             <li>Set {{MediaSource/[[live seekable range]]}} to be a new <a def-id="normalized-timeranges-object"></a>
@@ -665,7 +663,9 @@ interface MediaSource : EventTarget {
               </tr>
             </tbody>
           </table>
-        <div><em>Return type: </em>{{undefined}}</div></dd><dt><dfn><code>clearLiveSeekableRange</code></dfn></dt><dd>
+        <div><em>Return type: </em>{{undefined}}</div></dd>
+
+        <h3><dfn>clearLiveSeekableRange()</dfn> method</h3>
         <p>Updates {{MediaSource/[[live seekable range]]}} that is used in
           <a href="#htmlmediaelement-extensions">HTMLMediaElement Extensions</a> to modify
           {{HTMLMediaElement}}.{{HTMLMediaElement/seekable}} behavior.</p>
@@ -675,9 +675,9 @@ interface MediaSource : EventTarget {
             <li>If {{MediaSource/[[live seekable range]]}} contains a range, then set {{MediaSource/[[live seekable
               range]]}} to be a new empty {{TimeRanges}} object.
           </li></ol>
-        <div><em>No parameters.</em></div><div><em>Return type: </em>{{undefined}}</div></dd>
+        <div><em>No parameters.</em></div><div><em>Return type: </em>{{undefined}}</div>
 
-      <dt><dfn><code>isTypeSupported</code></dfn>, static</dt><dd>
+        <h3><dfn>isTypeSupported()</dfn> method</h3>
           <p>Check to see whether the <a>MediaSource</a> is capable of creating <a>SourceBuffer</a> objects for the specified MIME type.</p>
 
           <ol class="method-algorithm">
@@ -1237,8 +1237,8 @@ interface MediaSource : EventTarget {
     </section>
 
     <section id="mediasourcehandle">
-      <h2><dfn>MediaSourceHandle</dfn> Object</h2>
-      <p>The MediaSourceHandle object represents a proxy for a {{MediaSource}} object that is useful for attaching a
+      <h2><dfn>MediaSourceHandle</dfn> interface</h2>
+      <p>The {{MediaSourceHandle}} interface represents a proxy for a {{MediaSource}} object that is useful for attaching a
         {{DedicatedWorkerGlobalScope}} {{MediaSource}} to a {{Window}} {{HTMLMediaElement}} using
         {{HTMLMediaElement/srcObject}} as described in the [=attaching to a media element=] algorithm.</p>
 
@@ -1308,7 +1308,7 @@ interface MediaSourceHandle {};</pre>
     </section>
 
     <section id="sourcebuffer">
-      <h2><dfn>SourceBuffer</dfn> Object</h2>
+      <h2><dfn>SourceBuffer</dfn> interface</h2>
 
 
 <pre class="idl">enum AppendMode {
@@ -2645,8 +2645,8 @@ interface SourceBuffer : EventTarget {
     </section>
 
     <section id="sourcebufferlist">
-      <h2><dfn>SourceBufferList</dfn> Object</h2>
-      <p>SourceBufferList is a simple container object for <a>SourceBuffer</a> objects. It provides read-only array access and fires events when the list is modified.</p>
+      <h2><dfn>SourceBufferList</dfn> interface</h2>
+      <p>{{SourceBufferList}} is a simple container object for <a>SourceBuffer</a> objects. It provides read-only array access and fires events when the list is modified.</p>
 <pre class="idl">[Exposed=(Window,DedicatedWorker)]
 interface SourceBufferList : EventTarget {
     readonly        attribute unsigned long length;

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -695,7 +695,7 @@ interface MediaSource : EventTarget {
             This method returning true implies that HTMLMediaElement.canPlayType() will return "maybe" or "probably" since it does not make sense for a <a>MediaSource</a> to support a type the HTMLMediaElement knows it cannot play.
           </p>
         <table class="parameters"><tbody><tr><th>Parameter</th><th>Type</th><th>Nullable</th><th>Optional</th><th>Description</th></tr><tr><th class="prmName">|type|</th><td class="prmType">{{DOMString}}</td><td class="prmNullFalse"><span role="img" aria-label="False">✘</span></td><td class="prmOptFalse"><span role="img" aria-label="False">✘</span></td><td class="prmDesc"></td></tr></tbody></table><div><em>Return type: </em>{{boolean}}</div></dd></dl>
-      </section>
+
 
       <section id="mediasource-events">
         <h3>Event Summary</h3>
@@ -1234,6 +1234,7 @@ interface MediaSource : EventTarget {
           </dl>
         </section>
       </section>
+    </section>
     </section>
 
     <section id="mediasourcehandle">


### PR DESCRIPTION
So things are easier to find in the ToC. You can see the actual API shape now.  

<img width="392" alt="Screenshot 2023-10-23 at 14 52 30" src="https://github.com/w3c/media-source/assets/870154/1b16f366-f0b8-44d3-b350-47d98cb7d618">


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/pull/328.html" title="Last updated on Dec 18, 2023, 10:39 PM UTC (ee00d1c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/328/2cb6b9a...ee00d1c.html" title="Last updated on Dec 18, 2023, 10:39 PM UTC (ee00d1c)">Diff</a>