### PR TITLE
Update current wolenetz editor data

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -41,8 +41,6 @@
       ],
 
       formerEditors: [
-      { name: "Matthew Wolenetz",  note: "Until April 2023", url: "",
-      company: "Google Inc.", companyURL: "https://www.google.com/" },
       { name: "Jerry Smith", note: "Until September 2017", url: "",
       company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       { name: "Aaron Colwell", note: "Until April 2015",  url: "",

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -35,7 +35,7 @@
       { name: "Mark Watson", url: "",
       company: "Netflix Inc.", companyURL: "https://www.netflix.com/",
       w3cid: "46379" },
-      { name: "Matthew Wolenetz",  mailto:"matt.wolenetz@gmail.com", url: "",
+      { name: "Matthew Wolenetz",  mailto:"matt.wolenetz@gmail.com",
       company: "W3C Invited Expert",
       w3cid: "148095" },
       ],

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -35,12 +35,14 @@
       { name: "Mark Watson", url: "",
       company: "Netflix Inc.", companyURL: "https://www.netflix.com/",
       w3cid: "46379" },
-      { name: "Matthew Wolenetz",  mailto:"wolenetz@google.com", url: "",
-      company: "Google Inc.", companyURL: "https://www.google.com/",
-      w3cid: "76912" },
+      { name: "Matthew Wolenetz",  mailto:"matt.wolenetz@gmail.com", url: "",
+      note: "W3C Invited Expert since September 2023",
+      w3cid: "148095" },
       ],
 
       formerEditors: [
+      { name: "Matthew Wolenetz",  note: "Until April 2023", url: "",
+      company: "Google Inc.", companyURL: "https://www.google.com/" },
       { name: "Jerry Smith", note: "Until September 2017", url: "",
       company: "Microsoft Corporation", companyURL: "https://www.microsoft.com/" },
       { name: "Aaron Colwell", note: "Until April 2015",  url: "",

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -36,7 +36,7 @@
       company: "Netflix Inc.", companyURL: "https://www.netflix.com/",
       w3cid: "46379" },
       { name: "Matthew Wolenetz",  mailto:"matt.wolenetz@gmail.com", url: "",
-      note: "W3C Invited Expert since September 2023",
+      company: "W3C Invited Expert",
       w3cid: "148095" },
       ],
 


### PR DESCRIPTION
For now at least, I'm in two places: current and former editor lists. This seems to me to be the best way to show precise history of my associaton (previously Google, now a W3C Invited Expert). This change also updates my email to one that reaches me.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wolenetz/media-source/pull/333.html" title="Last updated on Oct 26, 2023, 1:37 AM UTC (0b5891f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/333/9fd0218...wolenetz:0b5891f.html" title="Last updated on Oct 26, 2023, 1:37 AM UTC (0b5891f)">Diff</a>