### PR TITLE
Fix the interface of the bufferedchange event in the summary table

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -2882,7 +2882,7 @@ interface SourceBufferList : EventTarget {
             <td>
               <dfn class="event">bufferedchange</dfn>
             </td>
-            <td>{{Event}}</td>
+            <td>{{BufferedChangeEvent}}</td>
             <td>
               The {{ManagedSourceBuffer}}'s buffered range changed following a
               call to {{SourceBuffer/appendBuffer()}}, {{SourceBuffer/remove()}},


### PR DESCRIPTION
The summary table that defines the `bufferedchange` event incorrectly associated the interface used by the event with `Event` instead of `BufferedChangeEvent`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/pull/344.html" title="Last updated on Dec 20, 2023, 11:01 AM UTC (5dd27f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/344/6bb43ff...5dd27f0.html" title="Last updated on Dec 20, 2023, 11:01 AM UTC (5dd27f0)">Diff</a>