### PR TITLE
BufferedChangeEventInit shouldn't be optional in BufferedChangeEvent constructor

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -2726,7 +2726,7 @@ interface SourceBufferList : EventTarget {
       <pre class="idl">
         [Exposed=(Window,DedicatedWorker)]
         interface BufferedChangeEvent : Event {
-          constructor(DOMString type, optional BufferedChangeEventInit eventInitDict = {});
+          constructor(DOMString type, BufferedChangeEventInit eventInitDict);
 
           [SameObject] readonly attribute TimeRanges addedRanges;
           [SameObject] readonly attribute TimeRanges removedRanges;


### PR DESCRIPTION
Fixes #349.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyavenard/media-source/pull/350.html" title="Last updated on Mar 18, 2024, 11:44 PM UTC (c5cb194)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/350/0f27243...jyavenard:c5cb194.html" title="Last updated on Mar 18, 2024, 11:44 PM UTC (c5cb194)">Diff</a>