### PR TITLE
Use bullets for list of substantive changes

### DIFF
--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -74,15 +74,24 @@
     </section>
     <section id="sotd">
       <p>
-        On top of editorial updates, substantives changes since publication as a W3C Recommendation
-        in <a href="https://www.w3.org/TR/2016/REC-media-source-20161117/">November 2016</a> are
-        the addition of a {{SourceBuffer/changeType()}} method to switch codecs, the possibility to
-        create and use {{MediaSource}} objects off the main thread in dedicated workers, the
-        removal of the {{URL/createObjectURL()}} extension to the {{URL}} object following its
-        integration in the File API [[FILEAPI]], and the addition of {{ManagedMediaSource}},
-        {{ManagedSourceBuffer}}, and {{BufferedChangeEvent}} interfaces supporting power-efficient
-        streaming and active buffered media cleanup by the user agent. For a full list of changes
-        done since the previous version, see the <a href=
+        On top of editorial updates, substantive changes since publication as a W3C Recommendation
+        in <a href="https://www.w3.org/TR/2016/REC-media-source-20161117/">November 2016</a> are:
+        <ul>
+          <li>the addition of a {{SourceBuffer/changeType()}} method to switch among codecs or
+          bytestreams
+          </li>
+          <li>the possibility to create and use {{MediaSource}} objects off the main thread in
+          dedicated workers
+          </li>
+          <li>the removal of the {{URL/createObjectURL()}} extension to the {{URL}} object following
+          its integration in the File API [[FILEAPI]]
+          </li>
+          <li>the addition of {{ManagedMediaSource}}, {{ManagedSourceBuffer}}, and
+          {{BufferedChangeEvent}} interfaces supporting power-efficient streaming and active buffered
+          media cleanup by the user agent
+          </li>
+        </ul>
+        For a full list of changes made since the previous version, see the <a href=
         "https://github.com/w3c/media-source/commits/main">commits</a>.
       </p>
       <p>

--- a/media-source-respec.html
+++ b/media-source-respec.html
@@ -76,6 +76,7 @@
       <p>
         On top of editorial updates, substantive changes since publication as a W3C Recommendation
         in <a href="https://www.w3.org/TR/2016/REC-media-source-20161117/">November 2016</a> are:
+        </p>
         <ul>
           <li>the addition of a {{SourceBuffer/changeType()}} method to switch among codecs or
           bytestreams
@@ -91,6 +92,7 @@
           media cleanup by the user agent
           </li>
         </ul>
+        <p>
         For a full list of changes made since the previous version, see the <a href=
         "https://github.com/w3c/media-source/commits/main">commits</a>.
       </p>


### PR DESCRIPTION
I was looking to resolve the merge conflicts in https://github.com/w3c/media-source/pull/302. As part of that, I noticed a change to the SotD section, to format the spec changes as a list, which would be good to merge independently of that PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/pull/353.html" title="Last updated on Apr 1, 2024, 7:14 AM UTC (25a986c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/media-source/353/5a1c99b...25a986c.html" title="Last updated on Apr 1, 2024, 7:14 AM UTC (25a986c)">Diff</a>